### PR TITLE
NOJIRA: Implement temp fix for portrait image detection

### DIFF
--- a/frontend/js/frontend.js
+++ b/frontend/js/frontend.js
@@ -12,6 +12,44 @@ function imgCheckPortrait($img) {
     }
 }
 
+// Temporary replacement for $.CFW_imageLoaded() until next
+// Figuration release.
+// Currently using: 4.0.0-beta.1
+function isImageLoaded($img, instance, callback) {
+    'use strict';
+
+    var img = $img[0];
+    var proxyImg = new Image();
+    var $proxyImg = $(proxyImg);
+
+    if (typeof instance === 'undefined') {
+        instance = '';
+    } else {
+        instance = '.' + instance;
+    }
+
+    var _doCallback = function() {
+        $proxyImg
+            .off('load.cfw.imageLoaded' + instance)
+            .remove();
+        callback();
+    };
+
+    var _isImageComplete = function() {
+        return img.complete && typeof img.naturalWidth !== 'undefined';
+    };
+
+    if (_isImageComplete() && img.naturalWidth !== 0) {
+        _doCallback();
+        return;
+    }
+
+    $proxyImg
+        .off('load.cfw.imageLoaded' + instance)
+        .one('load.cfw.imageLoaded' + instance, _doCallback);
+    proxyImg.src = img.src;
+};
+
 $(window).ready(function() {
     'use strict';
 
@@ -25,6 +63,6 @@ $(window).ready(function() {
         };
         /* eslint-enable no-loop-func */
 
-        $.CFW_imageLoaded($img, i, callback);
+        isImageLoaded($img, i, callback);
     }
 });


### PR DESCRIPTION
This is a temporary fix for the image load detection check for the images within the library cards and if they should be in 'portrait' mode.  

The upstream fix was made in Figuration, and will be included in the next release. This patch can then be removed when the package dependencies are updated.