### PR TITLE
CSL-187: No-op console.log() when not in debug mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ nltk==3.4.5
 lemminflect==0.2.0
 future==0.18.2
 numpy==1.17.4
+django-settings-export==1.2.1
 -e git+https://github.com/IMSGlobal/caliper-python@1.1.0.2#egg=imsglobal_caliper
 -e git+https://github.com/cast-org/django-session-timeout#egg=django-session-timeout

--- a/src/clusive_project/settings.py
+++ b/src/clusive_project/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Application definition
 
-INSTALLED_APPS = [    
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -60,6 +60,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'django_settings_export.settings_export',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
@@ -133,6 +134,11 @@ LOGGING = {
         }
     }
 }
+
+# Settings allowed to be exported
+SETTINGS_EXPORT = [
+    'DEBUG',
+];
 
 # Session settings
 SESSION_EXPIRE_SECONDS = 1800   # 30 minutes, in seconds

--- a/src/internal.js
+++ b/src/internal.js
@@ -2,6 +2,10 @@ import MarkLoader from 'script-loader!mark.js'
 
 window.cuedWordMap = null;
 
+if (!window.debug) {
+    console.log = function () {};
+}
+
 // Filter function that, when applied as part of Mark options, only marks up the first occurrence
 function onlyFirstMatch(node, term, totalCount, count) {
     "use strict";

--- a/src/shared/templates/shared/partial/head_scripts.html
+++ b/src/shared/templates/shared/partial/head_scripts.html
@@ -17,12 +17,21 @@ var DJANGO_STATIC_ROOT = "{% static '' %}"
 <script src="{% static 'shared/js/toc.js' %}"></script>
 <script src="{% static 'shared/js/tts.js' %}"></script>
 <script src="{% static 'shared/js/why.js' %}"></script>
+<!--<script src="{% static 'shared/js/context.js' %}"></script>-->
+
+<script>
+{% if settings.DEBUG %}
+    var debug = true;
+{% else %}
+    var debug = false;
+{% endif %}
+if (!debug) {
+    console.log = function () {};
+}
 
 {% if not user.is_anonymous %}
-<script>
-        fluid.contextAware.makeChecks({
-            "clusive.loggedInUser":  true
-        });
-</script>        
+    fluid.contextAware.makeChecks({
+        "clusive.loggedInUser":  true
+    });
 {% endif %}
-<script src="{% static 'shared/js/context.js' %}"></script>
+</script>


### PR DESCRIPTION
I know Alan has some ideas on how to handle reducing the console output, but wanted to toss this out there.

This might work to reduce most of the console output from both the Fluid and JS sides.

Concept uses Django's `DEBUG` setting as master setting to enable/disable.
This no-op method (while potentially inefficient) allows the console.log to be re-enabled in production if some remote debugging is needed.

~Still need to investigate how to pass this into the Readium frame.~

Thoughts?
