### PR TITLE
CSL-450: Add 'tooltip' to range slider

### DIFF
--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -180,8 +180,11 @@ function formRangeTip(range, callback) {
 
     var tip = document.createElement('div');
     tip.classList.add('form-range-tip');
-    tip.setAttribute('aria-hidden', true);
     range.after(tip);
+
+    var tipID = $(tip).CFW_getID('clusive_range');
+    tip.setAttribute('id', tipID);
+    range.setAttribute('aria-describedby', tipID);
 
     range.parentNode.classList.add('has-form-range-tip');
 

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -152,12 +152,62 @@ function formFileText() {
     });
 }
 
+function formRangeFontSize(range) {
+    'use strict';
+
+    var tip = range.parentNode.querySelector('.form-range-tip');
+    tip.innerText = (range.value * 16) + 'px';
+}
+
+function formRangeTipPosition(range) {
+    'use strict';
+
+    var tip = range.parentNode.querySelector('.form-range-tip');
+    var val = range.value;
+    var min = range.min ? range.min : 0;
+    var max = range.max ? range.max : 100;
+    // var percentage = Number(((val - min) * 100) / (max - min));
+    var ratio = Number(((val - min)) / (max - min));
+    var thumbWidth = 1.25;
+    var thumbHalfWidth = thumbWidth / 2;
+    var leftCalc = 'calc(' + ratio + ' * ((100% - ' + thumbHalfWidth + 'rem) - ' + thumbHalfWidth + 'rem) + ' + thumbHalfWidth + 'rem)';
+
+    tip.style.left = leftCalc;
+}
+
+function formRangeTip(range, callback) {
+    'use strict';
+
+    var tip = document.createElement('div');
+    tip.classList.add('form-range-tip');
+    tip.setAttribute('aria-hidden', true);
+    range.after(tip);
+
+    range.parentNode.classList.add('has-form-range-tip');
+
+    range.addEventListener('input', function() {
+        formRangeTipPosition(range);
+        callback(range);
+    });
+    window.addEventListener('resize', function() {
+        formRangeTipPosition(range);
+    });
+
+    formRangeTipPosition(range);
+    callback(range);
+}
+
 $(window).ready(function() {
     'use strict';
 
     formFileText();
     confirmationPublicationDelete();
     confirmationSharing();
+
+    var settingFontSize = document.querySelector('#set-size');
+    if (settingFontSize !== null) {
+        formRangeTip(settingFontSize, formRangeFontSize);
+    }
 
     var $imgs = $('.card-img img');
     for (var i = 0; i < $imgs.length; i++) {

--- a/src/frontend/scss/.stylelintrc
+++ b/src/frontend/scss/.stylelintrc
@@ -258,7 +258,7 @@
       "fill",
       "stroke"
     ],
-    "property-blacklist": [
+    "property-disallowed-list": [
       "border-radius",
       "border-top-left-radius",
       "border-top-right-radius",

--- a/src/frontend/scss/mixins/_site-theme.scss
+++ b/src/frontend/scss/mixins/_site-theme.scss
@@ -296,6 +296,7 @@
         --CT_formRangeThumbFocusBoxShadowRGB: #{red($form-range-thumb-focus-box-shadow-color), green($form-range-thumb-focus-box-shadow-color), blue($form-range-thumb-focus-box-shadow-color)};
         --CT_formRangeThumbFocusBoxShadowOpacity: #{$form-range-thumb-focus-box-shadow-opacity};
         --CT_formRangeThumbActiveBg: #{$form-range-thumb-active-bg};
+        --CT_formRangeTipColor: #{$form-range-tip-color};
 
         --CT_formSwitchTrackBg: #{$form-switch-track-bg};
         --CT_formSwitchTrackBorderColor: #{$form-switch-track-border-color};

--- a/src/frontend/scss/site-themes/_theme-default.scss
+++ b/src/frontend/scss/site-themes/_theme-default.scss
@@ -315,6 +315,7 @@ $form-range-thumb-box-shadow-opacity:   .9;
 $form-range-thumb-focus-box-shadow-color:       #636b82;
 $form-range-thumb-focus-box-shadow-opacity:     .85;
 $form-range-thumb-active-bg:            #ff554d;
+$form-range-tip-color:                  #666;
 
 // Form switch input
 $form-switch-track-bg:                      #d3cfc9;

--- a/src/frontend/scss/site-themes/_theme-night.scss
+++ b/src/frontend/scss/site-themes/_theme-night.scss
@@ -315,6 +315,7 @@ $form-range-thumb-box-shadow-opacity:   .9;
 $form-range-thumb-focus-box-shadow-color:       #a0abfd;
 $form-range-thumb-focus-box-shadow-opacity:     .85;
 $form-range-thumb-active-bg:            #ff554d;
+$form-range-tip-color:                  #eceff5;
 
 // Form switch input
 $form-switch-track-bg:                      #d3cfc9;

--- a/src/frontend/scss/site-themes/_theme-sepia.scss
+++ b/src/frontend/scss/site-themes/_theme-sepia.scss
@@ -315,6 +315,7 @@ $form-range-thumb-box-shadow-opacity:   .9;
 $form-range-thumb-focus-box-shadow-color:       #636b82;
 $form-range-thumb-focus-box-shadow-opacity:     .85;
 $form-range-thumb-active-bg:            #ff554d;
+$form-range-tip-color:                  #666;
 
 // Form switch input
 $form-switch-track-bg:                      #d3cfc9;

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -114,6 +114,20 @@ h2,
     }
 }
 
+.has-form-range-tip {
+    position: relative;
+    line-height: 1.5;
+}
+.form-range-tip {
+    position: absolute;
+    top: 0;
+    @include font-size(.875rem);
+    line-height: 1;
+    color: var(--CT_formRangeTipColor);
+    transform: translateX(-50%);
+    user-select: none;
+}
+
 .link-above {
     position: relative;
     z-index: 2;

--- a/src/frontend/scss/site/_setting.scss
+++ b/src/frontend/scss/site/_setting.scss
@@ -127,22 +127,31 @@
     &::before,
     &::after {
         position: absolute;
+        top: 1.625rem;
         display: inline-block;
         //stylelint-disable-next-line font-family-no-missing-generic-family-keyword
         font-family: Fontello;
+        line-height: 1;
         color: inherit;
         content: "\e812";
     }
 
     &::before {
-        top: 1.5rem;
         left: 0;
         @include font-size(.875rem);
     }
     &::after{
-        top: 1.25rem;
         right: 0;
         @include font-size(1.25rem);
+    }
+
+    &.has-form-range-tip {
+        padding-top: .875rem;
+
+        &::before,
+        &::after {
+            top: 2.5rem;
+        }
     }
 }
 


### PR DESCRIPTION
Currently part of CSL-400. Prototype example of adding 'tooltip' or visible value label to range inputs.

Included a 'callback' feature so tips can be updated on a case by case basis.

Will have to reconsider if it should be exposed to screen-readers instead of being hidden.