### PR TITLE
CSL-297: preference reset for message queue implementation

### DIFF
--- a/src/frontend/js/clusive-prefs-django-store.js
+++ b/src/frontend/js/clusive-prefs-django-store.js
@@ -63,14 +63,14 @@
             }
         );
 
-        window.addEventListener("beforeunload", function (e) {                 
-            if(! that.isQueueEmpty()) {
-                console.debug("queue is not empty, prompting user for unload");
-                that.flush();
-                e.preventDefault();
-                e.returnValue = "";        
-            }                        
-        });
+        // window.addEventListener("beforeunload", function (e) {                 
+        //     if(! that.isQueueEmpty()) {
+        //         console.debug("queue is not empty, prompting user for unload");
+        //         that.flush();
+        //         e.preventDefault();
+        //         e.returnValue = "";        
+        //     }                        
+        // });
 
     };
 
@@ -235,8 +235,9 @@
                     adopt: 'default'
                 })
             })
-                .done(function(data) {
-                    console.debug('resetting preferences to default', data);
+                .done(function(data) {                    
+                    console.debug('resetting preferences to default set', data);                    
+                    messageQueue.add({"type": "PC", "preferences": data});
                     clusive.prefs.djangoStore.getUserPreferences(directModel, messageQueue, lastRequestTime, that);                              
                 })
                 .fail(function(jqXHR, textStatus, errorThrown) {

--- a/src/frontend/js/clusive-prefs-django-store.js
+++ b/src/frontend/js/clusive-prefs-django-store.js
@@ -144,7 +144,7 @@
         listeners: {
             'onWrite.impl': {
                 listener: 'clusive.prefs.djangoStore.setUserPreferences',
-                args: ["{arguments}.0", "{arguments}.1", "{that}.messageQueue"]
+                args: ["{arguments}.0", "{arguments}.1", "{that}.messageQueue", "{that}.lastRequestTime", "{that}"]
             }
         },
         invokers: {
@@ -220,7 +220,7 @@
         return djangoStorePromise;
     };
 
-    clusive.prefs.djangoStore.setUserPreferences = function(model, directModel, messageQueue) {
+    clusive.prefs.djangoStore.setUserPreferences = function(model, directModel, messageQueue, lastRequestTime, that) {
         console.debug('clusive.prefs.djangoStore.setUserPreferences', directModel, model, messageQueue);
         
         // TODO: switch this over to use the messageQueue as well
@@ -237,7 +237,7 @@
             })
                 .done(function(data) {
                     console.debug('resetting preferences to default', data);
-                    clusive.prefs.djangoStore.getUserPreferences(directModel);
+                    clusive.prefs.djangoStore.getUserPreferences(directModel, messageQueue, lastRequestTime, that);                              
                 })
                 .fail(function(jqXHR, textStatus, errorThrown) {
                     console.error('an error occured trying to reset preferences', jqXHR, textStatus, errorThrown);

--- a/src/roster/views.py
+++ b/src/roster/views.py
@@ -67,7 +67,7 @@ class PreferenceSetView(View):
                 {'success': 0, 'message': 'Preference set named %s does not exist' % desired_prefs_name})
 
         # Replace all existing preferences with the new set.
-        # user.delete_preferences()
+        user.delete_preferences()
         set_user_preferences(user, desired_prefs, request)
 
         # Return the newly-established preferences


### PR DESCRIPTION
* Reset now working with new message queue implementation
* Remove the `beforeunload` event until it can be made to work only on logout (see https://castudl.atlassian.net/browse/CSL-463)