### PR TITLE
CSL-455:  TTS control update

### DIFF
--- a/src/frontend/html/library.html
+++ b/src/frontend/html/library.html
@@ -92,7 +92,7 @@
                 </div>
             </div>
 
-            <div class="sidebar sidebar-end" role="region" aria-label="Reading tools">
+            <div class="sidebar sidebar-end">
                 <div class="sidebar-tool" role="region" aria-label="User preferences">
                     <button type="button" class="btn btn-setting" aria-label="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
                         <span class="icon-settings" aria-hidden="true"></span>
@@ -103,7 +103,7 @@
                     </button>
                     -->
                 </div>
-                <div class="sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
                         <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>

--- a/src/frontend/html/library.html
+++ b/src/frontend/html/library.html
@@ -93,16 +93,33 @@
             </div>
 
             <div class="sidebar sidebar-end" role="region" aria-label="Reading tools">
-                <div class="sidebar-tool" role="region" aria-label="Reading tools">
+                <div class="sidebar-tool" role="region" aria-label="User preferences">
                     <button type="button" class="btn btn-setting" aria-label="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
                         <span class="icon-settings" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Read aloud">
-                        <span class="icon-play" aria-hidden="true"></span>
-                    </button>
+                    <!--
                     <button type="button" class="btn btn-tool" aria-label="Lookup definition">
                         <span class="icon-book" aria-hidden="true"></span>
                     </button>
+                    -->
+                </div>
+                <div class="sidebar-tts" role="region" aria-label="Text to speech controls">
+                    <div class="sidebar-tts-inactive">
+                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                    <div class="sidebar-tts-active">
+                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                            <span class="icon-pause" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                            <span class="icon-stop" aria-hidden="true"></span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/frontend/html/library.html
+++ b/src/frontend/html/library.html
@@ -103,20 +103,20 @@
                     </button>
                     -->
                 </div>
-                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="tts-region sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
-                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                        <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
                     </div>
                     <div class="sidebar-tts-active">
-                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                        <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
                             <span class="icon-pause" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                        <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                        <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
                             <span class="icon-stop" aria-hidden="true"></span>
                         </button>
                     </div>

--- a/src/frontend/html/modal.html
+++ b/src/frontend/html/modal.html
@@ -65,7 +65,7 @@ body {
                         <form>
                             <div class="setting">
                                 <fieldset>
-                                    <legend class="setting-title">Text size</legend>
+                                    <legend class="setting-title mb-0">Text size</legend>
                                     <div class="option-font-size">
                                         <label for="set-size" class="sr-only">Text size</label>
                                         <input id="set-size" type="range" class="form-range" min="0" max="5" step="1" value="1">
@@ -247,7 +247,42 @@ body {
                         </form>
                     </div>
                     <div id="setting1" class="tab-pane">
-                        Reading tools pane
+                        <!-- Reading Tools pane -->
+                        <form>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Voice</legend>
+                                    <div class="option-read-voice">
+                                        <button type="button" class="link-btn" data-cfw="dropdown">Female #1 <span class="caret" aria-hidden="true"></span></button>
+                                        <ul class="dropdown-menu dropreverse">
+                                            <li><button type="button" class="dropdown-item active">Female #1</button></li>
+                                            <li><button type="button" class="dropdown-item">Female #2</button></li>
+                                            <li><button type="button" class="dropdown-item">Male #1</button></li>
+                                            <li><button type="button" class="dropdown-item">Male #2</button></li>
+                                        </ul>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title mb-0">Speed</legend>
+                                    <div class="option-read-speed">
+                                        <label for="set-read-speed" class="sr-only">reading speed</label>
+                                        <input id="set-read-speed" type="range" class="form-range cislc-modalSettings-readSpeed" min="0.25" max="2" step="0.25" value="1">
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </form>
+                        <div class="setting d-none"></div>
+                        <div class="setting">
+                            <legend class="setting-title">Play sample</legend>
+                            <button type="button" class="btn btn-flag" aria-label="Play sample">
+                                <span class="icon-play" aria-hidden="true"></span>
+                            </button>
+                            <button type="button" class="btn btn-flag" aria-label="Stop sample" disabled>
+                                <span class="icon-stop" aria-hidden="true"></span>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/frontend/html/reader.html
+++ b/src/frontend/html/reader.html
@@ -116,7 +116,7 @@
                     </button>
                     -->
                 </div>
-                <div class="sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
                         <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>

--- a/src/frontend/html/reader.html
+++ b/src/frontend/html/reader.html
@@ -116,20 +116,20 @@
                     </button>
                     -->
                 </div>
-                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="tts-region sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
-                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                        <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
                     </div>
                     <div class="sidebar-tts-active">
-                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                        <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
                             <span class="icon-pause" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                        <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                        <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
                             <span class="icon-stop" aria-hidden="true"></span>
                         </button>
                     </div>

--- a/src/frontend/html/reader.html
+++ b/src/frontend/html/reader.html
@@ -106,16 +106,33 @@
             </div>
 
             <div class="sidebar sidebar-end">
-                <div class="sidebar-tool" role="region" aria-label="Reading tools">
+                <div class="sidebar-tool" role="region" aria-label="User preferences">
                     <button type="button" class="btn btn-setting" aria-label="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
                         <span class="icon-settings" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Read aloud">
-                        <span class="icon-play" aria-hidden="true"></span>
-                    </button>
+                    <!--
                     <button type="button" class="btn btn-tool" aria-label="Lookup definition">
                         <span class="icon-book" aria-hidden="true"></span>
                     </button>
+                    -->
+                </div>
+                <div class="sidebar-tts" role="region" aria-label="Text to speech controls">
+                    <div class="sidebar-tts-inactive">
+                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                    <div class="sidebar-tts-active">
+                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                            <span class="icon-pause" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                            <span class="icon-stop" aria-hidden="true"></span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/frontend/html/roster.html
+++ b/src/frontend/html/roster.html
@@ -97,20 +97,20 @@
                     </button>
                     -->
                 </div>
-                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="tts-region sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
-                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                        <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
                     </div>
                     <div class="sidebar-tts-active">
-                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                        <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
                             <span class="icon-pause" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                        <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                        <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
                             <span class="icon-stop" aria-hidden="true"></span>
                         </button>
                     </div>

--- a/src/frontend/html/roster.html
+++ b/src/frontend/html/roster.html
@@ -94,9 +94,6 @@
                     <button type="button" class="btn btn-tool" aria-label="Read aloud">
                         <span class="icon-play" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Lookup definition">
-                        <span class="icon-book" aria-hidden="true"></span>
-                    </button>
                 </div>
             </div>
         </div>

--- a/src/frontend/html/roster.html
+++ b/src/frontend/html/roster.html
@@ -86,14 +86,34 @@
                 </div>
             </div>
 
-            <div class="col-auto sidebar sidebar-end" role="region" aria-label="Reading tools">
-                <div class="sidebar-tool" role="region" aria-label="Reading tools">
+            <div class="sidebar sidebar-end">
+                <div class="sidebar-tool" role="region" aria-label="User preferences">
                     <button type="button" class="btn btn-setting" aria-label="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
                         <span class="icon-settings" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Read aloud">
-                        <span class="icon-play" aria-hidden="true"></span>
+                    <!--
+                    <button type="button" class="btn btn-tool" aria-label="Lookup definition">
+                        <span class="icon-book" aria-hidden="true"></span>
                     </button>
+                    -->
+                </div>
+                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                    <div class="sidebar-tts-inactive">
+                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                    <div class="sidebar-tts-active">
+                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                            <span class="icon-pause" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                            <span class="icon-stop" aria-hidden="true"></span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/frontend/html/wordbank.html
+++ b/src/frontend/html/wordbank.html
@@ -97,20 +97,20 @@
                     </button>
                     -->
                 </div>
-                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                <div class="tts-region sidebar-tts" role="region" aria-label="Text to speech controls">
                     <div class="sidebar-tts-inactive">
-                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                        <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
                     </div>
                     <div class="sidebar-tts-active">
-                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                        <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
                             <span class="icon-pause" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                        <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
                             <span class="icon-play" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                        <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
                             <span class="icon-stop" aria-hidden="true"></span>
                         </button>
                     </div>

--- a/src/frontend/html/wordbank.html
+++ b/src/frontend/html/wordbank.html
@@ -94,9 +94,6 @@
                     <button type="button" class="btn btn-tool" aria-label="Read aloud">
                         <span class="icon-play" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Lookup definition">
-                        <span class="icon-book" aria-hidden="true"></span>
-                    </button>
                 </div>
             </div>
         </div>

--- a/src/frontend/html/wordbank.html
+++ b/src/frontend/html/wordbank.html
@@ -86,14 +86,34 @@
                 </div>
             </div>
 
-            <div class="col-auto sidebar sidebar-end" role="region" aria-label="Reading tools">
-                <div class="sidebar-tool" role="region" aria-label="Reading tools">
+            <div class="sidebar sidebar-end">
+                <div class="sidebar-tool" role="region" aria-label="User preferences">
                     <button type="button" class="btn btn-setting" aria-label="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
                         <span class="icon-settings" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-tool" aria-label="Read aloud">
-                        <span class="icon-play" aria-hidden="true"></span>
+                    <!--
+                    <button type="button" class="btn btn-tool" aria-label="Lookup definition">
+                        <span class="icon-book" aria-hidden="true"></span>
                     </button>
+                    -->
+                </div>
+                <div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls">
+                    <div class="sidebar-tts-inactive">
+                        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                    <div class="sidebar-tts-active">
+                        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+                            <span class="icon-pause" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+                            <span class="icon-play" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+                            <span class="icon-stop" aria-hidden="true"></span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -159,6 +159,13 @@ function formRangeFontSize(range) {
     tip.innerText = (range.value * 16) + 'px';
 }
 
+function formRangeReadSpeed(range) {
+    'use strict';
+
+    var tip = range.parentNode.querySelector('.form-range-tip');
+    tip.innerText = range.value;
+}
+
 function formRangeTipPosition(range) {
     'use strict';
 
@@ -210,6 +217,10 @@ $(window).ready(function() {
     var settingFontSize = document.querySelector('#set-size');
     if (settingFontSize !== null) {
         formRangeTip(settingFontSize, formRangeFontSize);
+    }
+    var settingReadSpeed = document.querySelector('#set-read-speed');
+    if (settingReadSpeed !== null) {
+        formRangeTip(settingReadSpeed, formRangeReadSpeed);
     }
 
     var $imgs = $('.card-img img');

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -9,13 +9,20 @@ var clusiveTTS = {
     readiumReadAloudButtonId: '#readiumReadAloud',
     readAloudButtonId: '#readAloudButton',
     readAloudButtonPlayAriaLabel: 'Read aloud',
-    readAloudButtonStopAriaLabel: 'Stop reading aloud',
-    readAloudIconId: '#readAloudIcon',
-    readAloudSrTextId: '#readAloudSrText'
+    readAloudButtonStopAriaLabel: 'Stop reading aloud'
+};
+
+var clusiveTTSRegionFromControl = function(ctl) {
+    'use strict';
+
+    var output = {};
+    output.region = ctl.closest('.region-tts');
+    output.mode = typeof(output.region.dataset.mode) !== "undefined" ? output.region.dataset.mode : null;
+
+    return output;
 };
 
 // Bind controls
-
 $(document).ready(function() {
     'use strict';
 
@@ -44,6 +51,9 @@ $(document).ready(function() {
             clusiveTTS.stopReading();
         }
     });
+
+    D2Reader.pauseReadAloud()
+    D2Reader.resumeReadAloud()
 });
 
 clusiveTTS.toggleButtonToPlay = function(id) {

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -21,18 +21,21 @@ $(document).ready(function() {
             console.debug('Readium read aloud play button clicked');
             if (!clusiveTTS.synth.speaking) {
                 D2Reader.startReadAloud();
+                clusiveTTS.updateUI('play');
             } else {
                 D2Reader.stopReadAloud();
+                clusiveTTS.updateUI('stop');
             }
         } else {
             console.debug('read aloud play button clicked');
             if (!clusiveTTS.synth.speaking) {
                 clusiveTTS.read();
+                clusiveTTS.updateUI('play');
             } else {
                 clusiveTTS.stopReading();
+                clusiveTTS.updateUI('stop');
             }
         }
-        clusiveTTS.updateUI();
     });
 
     $('.tts-stop').on('click', function(e) {
@@ -45,7 +48,7 @@ $(document).ready(function() {
             console.debug('read aloud stop button clicked');
             clusiveTTS.stopReading();
         }
-        clusiveTTS.updateUI();
+        clusiveTTS.updateUI('stop');
     });
 
     $('.tts-pause').on('click', function(e) {
@@ -58,20 +61,20 @@ $(document).ready(function() {
             console.debug('read aloud pause button clicked');
             clusiveTTS.synth.pause();
         }
-        clusiveTTS.updateUI();
+        clusiveTTS.updateUI('pause');
     });
 
     $('.tts-resume').on('click', function(e) {
         clusiveTTS.setRegion(e.currentTarget);
 
         if (clusiveTTS.region.mode === 'Readium') {
-            console.debug('Readium read aloud pause button clicked');
+            console.debug('Readium read aloud resume button clicked');
             D2Reader.resumeReadAloud();
         } else {
-            console.debug('read aloud pause button clicked');
+            console.debug('read aloud resume button clicked');
             clusiveTTS.synth.resume();
         }
-        clusiveTTS.updateUI();
+        clusiveTTS.updateUI('resume');
     });
 });
 
@@ -89,6 +92,7 @@ clusiveTTS.setRegion = function(ctl) {
             console.debug('read aloud stop on region change');
             clusiveTTS.stopReading();
         }
+        clusiveTTS.updateUI('stop');
     }
 
     if (clusiveTTS.region.elm !== newRegion.elm) {
@@ -96,13 +100,16 @@ clusiveTTS.setRegion = function(ctl) {
     }
 }
 
-clusiveTTS.updateUI = function() {
+clusiveTTS.updateUI = function(mode) {
     'use strict';
 
     if (!Object.keys(clusiveTTS.region).length) { return; }
 
     var region = clusiveTTS.region.elm;
 
+    /*
+     * Partially works, are speechSynthesis methods async() ?
+     *
     if (clusiveTTS.synth.paused) {
         region.classList.add('paused');
     } else {
@@ -115,6 +122,25 @@ clusiveTTS.updateUI = function() {
         region.classList.remove('paused');
         region.classList.remove('active');
         clusiveTTS.region = {};
+    }
+    */
+
+    switch(mode) {
+        case 'resume':
+        case 'play': {
+            region.classList.remove('paused');
+            region.classList.add('active');
+            break;
+        }
+        case 'pause': {
+            region.classList.add('paused');
+            region.classList.add('active');
+            break;
+        }
+        default: {
+            region.classList.remove('paused');
+            region.classList.remove('active');
+        }
     }
 };
 
@@ -133,7 +159,7 @@ clusiveTTS.readQueuedElements = function() {
         clusiveTTS.readElement(toRead.element, toRead.offset, end);
     } else {
         console.debug('Done reading elements');
-        clusiveTTS.updateUI();
+        clusiveTTS.updateUI('stop');
     }
 };
 

--- a/src/frontend/scss/mixins/_site-theme.scss
+++ b/src/frontend/scss/mixins/_site-theme.scss
@@ -147,6 +147,17 @@
         --CT_btnOptionActiveBoxShadowOpacity: #{$btn-option-active-box-shadow-opacity};
         --CT_btnOptionActiveHoverBorderColor: #{$btn-option-active-hover-border-color};
 
+        --CT_btnTtsFocusRingRGB: #{red($btn-tts-focus-ring), green($btn-tts-focus-ring), blue($btn-tts-focus-ring)};
+        --CT_btnTtsBg: #{$btn-tts-bg};
+        --CT_btnTtsColor: #{$btn-tts-color};
+        --CT_btnTtsBorderColor: #{$btn-tts-border-color};
+        --CT_btnTtsHoverBg: #{$btn-tts-hover-bg};
+        --CT_btnTtsHoverColor: #{$btn-tts-hover-color};
+        --CT_btnTtsHoverBorderColor: #{$btn-tts-hover-border-color};
+        --CT_btnTtsActiveBg: #{$btn-tts-active-bg};
+        --CT_btnTtsActiveColor: #{$btn-tts-active-color};
+        --CT_btnTtsActiveBorderColor: #{$btn-tts-active-border-color};
+
         --CT_btnFlagFocusRingRGB: #{red($btn-flag-focus-ring), green($btn-flag-focus-ring), blue($btn-flag-focus-ring)};
         --CT_btnFlagBg: #{$btn-flag-bg};
         --CT_btnFlagColor: #{$btn-flag-color};
@@ -332,6 +343,8 @@
 
         --CT_ttsBackgroundColor: #{$tts-highlight-bg};
         --CT_ttsTextColor: #{$tts-highlight-color};
+
+        --CT_sidebarTtsActiveBg: #{$sidebar-tts-active-bg};
 
         --CT_imageDescCiteColor: #{$image-desc-cite-color};
 

--- a/src/frontend/scss/site-themes/_theme-default.scss
+++ b/src/frontend/scss/site-themes/_theme-default.scss
@@ -140,6 +140,17 @@ $btn-tool-active-bg:                    rgba(#acfdf0, 1);
 $btn-tool-active-color:                 $btn-tool-color;
 $btn-tool-active-border-color:          transparent;
 
+$btn-tts-focus-ring:                    #636b82;
+$btn-tts-bg:                            #ff554d;
+$btn-tts-color:                         #111;
+$btn-tts-border-color:                  transparent;
+$btn-tts-hover-bg:                      #6268ad;
+$btn-tts-hover-color:                   #fbfbfb;
+$btn-tts-hover-border-color:            transparent;
+$btn-tts-active-bg:                     palette($btn-tts-hover-bg, 600);
+$btn-tts-active-color:                  $btn-tts-hover-color;
+$btn-tts-active-border-color:           transparent;
+
 $btn-option-focus-ring:                 #636b82;
 $btn-option-bg:                         #fff;
 $btn-option-color:                      #333;
@@ -351,6 +362,8 @@ $wordbank-count-empty-border-color:     #636b82;
 // Text-to-Speech (TTS)
 $tts-highlight-bg:                      #fffd38;
 $tts-highlight-color:                   #636b82;
+
+$sidebar-tts-active-bg:                 #ff554d;
 
 // Glossary/definitions
 $glossary-underline:                    #acfdf0;

--- a/src/frontend/scss/site-themes/_theme-night.scss
+++ b/src/frontend/scss/site-themes/_theme-night.scss
@@ -140,6 +140,17 @@ $btn-tool-active-bg:                    palette($btn-tool-bg, 425);
 $btn-tool-active-color:                 $btn-tool-color;
 $btn-tool-active-border-color:          transparent;
 
+$btn-tts-focus-ring:                    #a0abfd;
+$btn-tts-bg:                            #ff554d;
+$btn-tts-color:                         #111;
+$btn-tts-border-color:                  transparent;
+$btn-tts-hover-bg:                      #6268ad;
+$btn-tts-hover-color:                   #fbfbfb;
+$btn-tts-hover-border-color:            transparent;
+$btn-tts-active-bg:                     palette($btn-tts-hover-bg, 600);
+$btn-tts-active-color:                  $btn-tts-hover-color;
+$btn-tts-active-border-color:           transparent;
+
 $btn-option-focus-ring:                 #a0abfd;
 $btn-option-bg:                         #fff;
 $btn-option-color:                      #333;
@@ -351,6 +362,8 @@ $wordbank-count-empty-border-color:     #636b82;
 // Text-to-Speech (TTS)
 $tts-highlight-bg:                      #fd6;
 $tts-highlight-color:                   #636b82;
+
+$sidebar-tts-active-bg:                 #ff554d;
 
 // Glossary/definitions
 $glossary-underline:                    #ff554d;

--- a/src/frontend/scss/site-themes/_theme-sepia.scss
+++ b/src/frontend/scss/site-themes/_theme-sepia.scss
@@ -140,6 +140,17 @@ $btn-tool-active-bg:                    palette($btn-tool-bg, 100);
 $btn-tool-active-color:                 $btn-tool-color;
 $btn-tool-active-border-color:          transparent;
 
+$btn-tts-focus-ring:                    #636b82;
+$btn-tts-bg:                            #ff554d;
+$btn-tts-color:                         #111;
+$btn-tts-border-color:                  transparent;
+$btn-tts-hover-bg:                      #6268ad;
+$btn-tts-hover-color:                   #fbfbfb;
+$btn-tts-hover-border-color:            transparent;
+$btn-tts-active-bg:                     palette($btn-tts-hover-bg, 600);
+$btn-tts-active-color:                  $btn-tts-hover-color;
+$btn-tts-active-border-color:           transparent;
+
 $btn-option-focus-ring:                 #636b82;
 $btn-option-bg:                         #fff;
 $btn-option-color:                      #333;
@@ -351,6 +362,8 @@ $wordbank-count-empty-border-color:     #636b82;
 // Text-to-Speech (TTS)
 $tts-highlight-bg:                      #fd6;
 $tts-highlight-color:                   #636b82;
+
+$sidebar-tts-active-bg:                 #ff554d;
 
 // Glossary/definitions
 $glossary-underline:                    #a0abfd;

--- a/src/frontend/scss/site/_button.scss
+++ b/src/frontend/scss/site/_button.scss
@@ -1,7 +1,8 @@
 .btn-support,
 .btn-nav,
 .btn-setting,
-.btn-tool {
+.btn-tool,
+.btn-tts {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -21,7 +22,8 @@
 }
 
 .btn-setting,
-.btn-tool {
+.btn-tool,
+.btn-tts {
     @include font-size(1.75rem);
 }
 

--- a/src/frontend/scss/site/_setting.scss
+++ b/src/frontend/scss/site/_setting.scss
@@ -196,3 +196,39 @@
         @include sample-theme($fg, $bg, $bc);
     }
 }
+
+// Reading Options
+
+.option-read-speed {
+    position: relative;
+    margin-bottom: 1.25rem;
+
+    &::before,
+    &::after {
+        position: absolute;
+        top: 1.625rem;
+        display: inline-block;
+        @include font-size(.875rem);
+        line-height: 1;
+        color: inherit;
+        content: "\e812";
+    }
+
+    &::before {
+        left: 0;
+        content: "slow";
+    }
+    &::after{
+        right: 0;
+        content: "fast";
+    }
+
+    &.has-form-range-tip {
+        padding-top: .875rem;
+
+        &::before,
+        &::after {
+            top: 2.5rem;
+        }
+    }
+}

--- a/src/frontend/scss/site/_sidebar.scss
+++ b/src/frontend/scss/site/_sidebar.scss
@@ -127,3 +127,41 @@
         margin-top: .75rem;
     }
 }
+
+.sidebar-tts {
+    margin-top: .75rem;
+    width: 2.5rem;
+    @include border-radius(2.5rem);
+
+    .btn {
+        @include border-radius(10rem);
+    }
+
+    .sidebar-tts-stop {
+        margin-top: .25rem;
+    }
+
+    &.active {
+        background-color: var(--CT_sidebarTtsActiveBg);
+
+        .sidebar-tts-inactive {
+            display: none;
+        }
+    }
+    &:not(.active) {
+        .sidebar-tts-active {
+            display: none;
+        }
+    }
+
+    &.paused {
+        .sidebar-tts-pause {
+            display: none;
+        }
+    }
+    &:not(.paused) {
+        .sidebar-tts-resume {
+            display: none;
+        }
+    }
+}

--- a/src/frontend/scss/site/_sidebar.scss
+++ b/src/frontend/scss/site/_sidebar.scss
@@ -137,7 +137,7 @@
         @include border-radius(10rem);
     }
 
-    .sidebar-tts-stop {
+    .tts-stop {
         margin-top: .25rem;
     }
 
@@ -155,12 +155,12 @@
     }
 
     &.paused {
-        .sidebar-tts-pause {
+        .tts-pause {
             display: none;
         }
     }
     &:not(.paused) {
-        .sidebar-tts-resume {
+        .tts-resume {
             display: none;
         }
     }

--- a/src/frontend/scss/site/_site-post.scss
+++ b/src/frontend/scss/site/_site-post.scss
@@ -88,6 +88,19 @@ $btn-themes: map-merge(
             "active-color": var(--CT_btnToolActiveColor),
             "active-border-color": var(--CT_btnToolActiveBorderColor)
         ),
+        "tts":
+        (
+            "base": var(--CT_btnTtsFocusRingRGB),
+            "bg": var(--CT_btnTtsBg),
+            "color": var(--CT_btnTtsColor),
+            "border-color": var(--CT_btnTtsBorderColor),
+            "hover-bg": var(--CT_btnTtsHoverBg),
+            "hover-color": var(--CT_btnTtsHoverColor),
+            "hover-border-color": var(--CT_btnTtsHoverBorderColor),
+            "active-bg": var(--CT_btnTtsActiveBg),
+            "active-color": var(--CT_btnTtsActiveColor),
+            "active-border-color": var(--CT_btnTtsActiveBorderColor)
+        ),
         "option":
         (
             "base": var(--CT_btnOptionFocusRingRGB),

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -85,7 +85,8 @@ $enable-tooltip:                        true;
 $enable-utility-bg:                     false;
 $enable-utility-border:                 false;
 $enable-utility-clearfix:               false;
-$enable-utility-display:                false;
+$enable-utility-display-down-none:      false;
+$enable-utility-display-print:          false;
 $enable-utility-flex:                   false;
 $enable-utility-float:                  false;
 $enable-utility-overflow:               false;
@@ -119,6 +120,8 @@ $enable-utility-visibility:             false;
 
 // Default Figuration setting overrides
 // =====
+
+$utility-display:                       none;
 
 // Disable some default box-shadows
 $thumbnail-box-shadow:                  0 0 transparent;

--- a/src/shared/templates/shared/partial/modal_settings.html
+++ b/src/shared/templates/shared/partial/modal_settings.html
@@ -11,176 +11,222 @@
                 <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close" title="Close">
                     <span class="icon-cancel" aria-hidden="true"></span>
                 </button>
+                <ul class="nav nav-tabs-setting d-none">
+                    <li class="nav-item"><a href="#setting0" class="nav-link" data-cfw="tab">Display</a></li>
+                    <li class="nav-item"><a href="#setting1" class="nav-link" data-cfw="tab">Reading Tools</a></li>
+                </ul>
             </div>
             <div class="modal-body">
-                <form>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Text size</legend>
-                            <div class="option-font-size">
-                                <label for="set-size" class="sr-only">Text size</label>
-                                <input id="set-size" type="range" class="form-range cislc-modalSettings-textSize" min="0.9" max="2" step="0.1" value="1">
+                <div class="tab-content">
+                    <div id="setting0" class="tab-pane">
+                        <form>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title mb-0">Text size</legend>
+                                    <div class="option-font-size">
+                                        <label for="set-size" class="sr-only">Text size</label>
+                                        <input id="set-size" type="range" class="form-range cislc-modalSettings-textSize" min="0.9" max="2" step="0.1" value="1">
+                                    </div>
+                                </fieldset>
                             </div>
-                        </fieldset>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Line spacing</legend>
+                                    <div class="setting-btn-row">
+                                        <div class="btn-check">
+                                            <input id="option-line-height-1" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="default" type="radio">
+                                            <label for="option-line-height-1" class="btn btn-option" title="Single">
+                                                <span class="icon-line-height-1" aria-hidden="true"></span>
+                                                <span class="sr-only">Single</span>
+                                            </label>
+                                        </div>
+                                        <div class="btn-check">
+                                            <input id="option-line-height-2" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="tall" type="radio" checked>
+                                            <label for="option-line-height-2" class="btn btn-option" title="Double">
+                                                <span class="icon-line-height-2" aria-hidden="true"></span>
+                                                <span class="sr-only">Double</span>
+                                            </label>
+                                        </div>
+                                        <div class="btn-check">
+                                            <input id="option-line-height-3" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="taller" type="radio">
+                                            <label for="option-line-height-3" class="btn btn-option" title="Triple">
+                                                <span class="icon-line-height-3" aria-hidden="true"></span>
+                                                <span class="sr-only">Triple</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Letter spacing</legend>
+                                    <div class="setting-btn-row">
+                                        <div class="btn-check">
+                                            <input id="option-letter-spacing-1" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" type="radio" value="default" checked>
+                                            <label for="option-letter-spacing-1" class="btn btn-option" title="Tight">
+                                                <span class="icon-text-space-1" aria-hidden="true"></span>
+                                                <span class="sr-only">Tight</span>
+                                            </label>
+                                        </div>
+                                        <div class="btn-check">
+                                            <input id="option-letter-spacing-2" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" value="wide" type="radio">
+                                            <label for="option-letter-spacing-2" class="btn btn-option" title="Medium">
+                                                <span class="icon-text-space-2" aria-hidden="true"></span>
+                                                <span class="sr-only">Medium</span>
+                                            </label>
+                                        </div>
+                                        <div class="btn-check">
+                                            <input id="option-letter-spacing-3" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" value="wider" type="radio">
+                                            <label for="option-letter-spacing-3" class="btn btn-option" title="Wide">
+                                                <span class="icon-text-space-3" aria-hidden="true"></span>
+                                                <span class="sr-only">Wide</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Font</legend>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-0" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="default" type="radio" checked>
+                                        <label for="option-font-family-0" id="ff-default" class="form-check-label">Default</label>
+                                    </div>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-1" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="times" type="radio">
+                                        <label for="option-font-family-1" id="ff-times" class="form-check-label">Times New Roman</label>
+                                    </div>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-2" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="comic" type="radio">
+                                        <label for="option-font-family-2" id="ff-comic" class="form-check-label">Comic Sans</label>
+                                    </div>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-3" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="arial" type="radio">
+                                        <label for="option-font-family-3" id="ff-arial" class="form-check-label">Arial</label>
+                                    </div>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-4" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="verdana" type="radio">
+                                        <label for="option-font-family-4" id="ff-verdana" class="form-check-label">Verdana</label>
+                                    </div>
+                                    <div class="form-check form-checkradio">
+                                        <input id="option-font-family-5" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="open-dyslexic" type="radio">
+                                        <label for="option-font-family-5" id="ff-dyslexic" class="form-check-label">Open Dyslexic</label>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Color</legend>
+                                    <div class="setting-btn-row option-color-theme">
+                                        <div class="form-check form-checkradio">
+                                            <input id="option-color-theme-0" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="default" checked>
+                                            <label for="option-color-theme-0" class="form-check-label">
+                                                <span class="sr-only">White</span>
+                                                <span class="theme-sample theme-sample-default" aria-hidden="true" title="White">a</span>
+                                            </label>
+                                        </div>
+                                        <div class="form-check form-checkradio">
+                                            <input id="option-color-theme-1" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="sepia">
+                                            <label for="option-color-theme-1" class="form-check-label">
+                                                <span class="sr-only">Sepia</span>
+                                                <span class="theme-sample theme-sample-sepia" aria-hidden="true" title="Sepia">a</span>
+                                            </label>
+                                        </div>
+                                        <div class="form-check form-checkradio">
+                                            <input id="option-color-theme-2" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="night">
+                                            <label for="option-color-theme-2" class="form-check-label">
+                                                <span class="sr-only">Dark</span>
+                                                <span class="theme-sample theme-sample-night" aria-hidden="true" title="Dark">a</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Word lookup links</legend>
+                                    <div class="form-switch-dual">
+                                        <label for="option-lookup-links" class="form-check-label-pre" aria-hidden="true">Hide</label>
+                                        <div class="form-check form-switch">
+                                            <input id="option-lookup-links" name="option-glossary" class="form-check-input cislc-modalSettings-glossary" type="checkbox">
+                                            <label for="option-lookup-links" class="form-check-label">Show</label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            {% comment %}
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Columns</legend>
+                                    <div class="setting-btn-row">
+                                        <div class="btn-check">
+                                            <input id="option-column-count-1" name="option-column-count" class="btn-check-input" type="radio" checked>
+                                            <label for="option-column-count-1" class="btn btn-xlarge btn-option">
+                                                <span class="icon-column-1" aria-hidden="true"></span>
+                                                <span class="sr-only">Single</span>
+                                            </label>
+                                        </div>
+                                        <div class="btn-check">
+                                            <input id="option-column-count-2" name="option-column-count" class="btn-check-input" type="radio">
+                                            <label for="option-column-count-2" class="btn btn-xlarge btn-option">
+                                                <span class="icon-column-2" aria-hidden="true"></span>
+                                                <span class="sr-only">Double</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Lookup</legend>
+                                    <div class="form-check form-switch">
+                                        <input id="option-lookup" class="form-check-input" type="checkbox">
+                                        <label for="option-lookup" class="form-check-label">Enable</label>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            {% endcomment %}
+                        </form>
                     </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Line spacing</legend>
-                            <div class="setting-btn-row">
-                                <div class="btn-check">
-                                    <input id="option-line-height-1" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="default" type="radio">
-                                    <label for="option-line-height-1" class="btn btn-option" title="Single">
-                                        <span class="icon-line-height-1" aria-hidden="true"></span>
-                                        <span class="sr-only">Single</span>
-                                    </label>
-                                </div>
-                                <div class="btn-check">
-                                    <input id="option-line-height-2" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="tall" type="radio" checked>
-                                    <label for="option-line-height-2" class="btn btn-option" title="Double">
-                                        <span class="icon-line-height-2" aria-hidden="true"></span>
-                                        <span class="sr-only">Double</span>
-                                    </label>
-                                </div>
-                                <div class="btn-check">
-                                    <input id="option-line-height-3" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="taller" type="radio">
-                                    <label for="option-line-height-3" class="btn btn-option" title="Triple">
-                                        <span class="icon-line-height-3" aria-hidden="true"></span>
-                                        <span class="sr-only">Triple</span>
-                                    </label>
-                                </div>
+                    <div id="setting1" class="tab-pane">
+                        <!-- Reading Tools pane -->
+                        <form>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title">Voice</legend>
+                                    <div class="option-read-voice">
+                                        <button type="button" class="link-btn" data-cfw="dropdown">Female #1 <span class="caret" aria-hidden="true"></span></button>
+                                        <ul class="dropdown-menu dropreverse">
+                                            <li><button type="button" class="dropdown-item active">Female #1</button></li>
+                                            <li><button type="button" class="dropdown-item">Female #2</button></li>
+                                            <li><button type="button" class="dropdown-item">Male #1</button></li>
+                                            <li><button type="button" class="dropdown-item">Male #2</button></li>
+                                        </ul>
+                                    </div>
+                                </fieldset>
                             </div>
-                        </fieldset>
+                            <div class="setting">
+                                <fieldset>
+                                    <legend class="setting-title mb-0">Speed</legend>
+                                    <div class="option-read-speed">
+                                        <label for="set-read-speed" class="sr-only">reading speed</label>
+                                        <input id="set-read-speed" type="range" class="form-range cislc-modalSettings-readSpeed" min="0.25" max="2" step="0.25" value="1">
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </form>
+                        <div class="setting d-none"></div>
+                        <div class="setting">
+                            <legend class="setting-title">Play sample</legend>
+                            <button type="button" class="btn btn-flag" aria-label="Play sample">
+                                <span class="icon-play" aria-hidden="true"></span>
+                            </button>
+                            <button type="button" class="btn btn-flag" aria-label="Stop sample" disabled>
+                                <span class="icon-stop" aria-hidden="true"></span>
+                            </button>
+                        </div>
                     </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Letter spacing</legend>
-                            <div class="setting-btn-row">
-                                <div class="btn-check">
-                                    <input id="option-letter-spacing-1" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" type="radio" value="default" checked>
-                                    <label for="option-letter-spacing-1" class="btn btn-option" title="Tight">
-                                        <span class="icon-text-space-1" aria-hidden="true"></span>
-                                        <span class="sr-only">Tight</span>
-                                    </label>
-                                </div>
-                                <div class="btn-check">
-                                    <input id="option-letter-spacing-2" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" value="wide" type="radio">
-                                    <label for="option-letter-spacing-2" class="btn btn-option" title="Medium">
-                                        <span class="icon-text-space-2" aria-hidden="true"></span>
-                                        <span class="sr-only">Medium</span>
-                                    </label>
-                                </div>
-                                <div class="btn-check">
-                                    <input id="option-letter-spacing-3" name="option-letter-spacing" class="btn-check-input cislc-modalSettings-letterSpacing" value="wider" type="radio">
-                                    <label for="option-letter-spacing-3" class="btn btn-option" title="Wide">
-                                        <span class="icon-text-space-3" aria-hidden="true"></span>
-                                        <span class="sr-only">Wide</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Font</legend>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-0" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="default" type="radio" checked>
-                                <label for="option-font-family-0" id="ff-default" class="form-check-label">Default</label>
-                            </div>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-1" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="times" type="radio">
-                                <label for="option-font-family-1" id="ff-times" class="form-check-label">Times New Roman</label>
-                            </div>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-2" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="comic" type="radio">
-                                <label for="option-font-family-2" id="ff-comic" class="form-check-label">Comic Sans</label>
-                            </div>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-3" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="arial" type="radio">
-                                <label for="option-font-family-3" id="ff-arial" class="form-check-label">Arial</label>
-                            </div>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-4" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="verdana" type="radio">
-                                <label for="option-font-family-4" id="ff-verdana" class="form-check-label">Verdana</label>
-                            </div>
-                            <div class="form-check form-checkradio">
-                                <input id="option-font-family-5" name="option-font-family" class="form-check-input cislc-modalSettings-font" value="open-dyslexic" type="radio">
-                                <label for="option-font-family-5" id="ff-dyslexic" class="form-check-label">Open Dyslexic</label>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Color</legend>
-                            <div class="setting-btn-row option-color-theme">
-                                <div class="form-check form-checkradio">
-                                    <input id="option-color-theme-0" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="default" checked>
-                                    <label for="option-color-theme-0" class="form-check-label">
-                                        <span class="sr-only">White</span>
-                                        <span class="theme-sample theme-sample-default" aria-hidden="true" title="White">a</span>
-                                    </label>
-                                </div>
-                                <div class="form-check form-checkradio">
-                                    <input id="option-color-theme-1" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="sepia">
-                                    <label for="option-color-theme-1" class="form-check-label">
-                                        <span class="sr-only">Sepia</span>
-                                        <span class="theme-sample theme-sample-sepia" aria-hidden="true" title="Sepia">a</span>
-                                    </label>
-                                </div>
-                                <div class="form-check form-checkradio">
-                                    <input id="option-color-theme-2" name="option-color-theme" class="form-check-input cislc-modalSettings-color" type="radio" value="night">
-                                    <label for="option-color-theme-2" class="form-check-label">
-                                        <span class="sr-only">Dark</span>
-                                        <span class="theme-sample theme-sample-night" aria-hidden="true" title="Dark">a</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Word lookup links</legend>
-                            <div class="form-switch-dual">
-                                <label for="option-lookup-links" class="form-check-label-pre" aria-hidden="true">Hide</label>
-                                <div class="form-check form-switch">
-                                    <input id="option-lookup-links" name="option-glossary" class="form-check-input cislc-modalSettings-glossary" type="checkbox">
-                                    <label for="option-lookup-links" class="form-check-label">Show</label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    {% comment %}
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Columns</legend>
-                            <div class="setting-btn-row">
-                                <div class="btn-check">
-                                    <input id="option-column-count-1" name="option-column-count" class="btn-check-input" type="radio" checked>
-                                    <label for="option-column-count-1" class="btn btn-xlarge btn-option">
-                                        <span class="icon-column-1" aria-hidden="true"></span>
-                                        <span class="sr-only">Single</span>
-                                    </label>
-                                </div>
-                                <div class="btn-check">
-                                    <input id="option-column-count-2" name="option-column-count" class="btn-check-input" type="radio">
-                                    <label for="option-column-count-2" class="btn btn-xlarge btn-option">
-                                        <span class="icon-column-2" aria-hidden="true"></span>
-                                        <span class="sr-only">Double</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <div class="setting">
-                        <fieldset>
-                            <legend class="setting-title">Lookup</legend>
-                            <div class="form-check form-switch">
-                                <input id="option-lookup" class="form-check-input" type="checkbox">
-                                <label for="option-lookup" class="form-check-label">Enable</label>
-                            </div>
-                        </fieldset>
-                    </div>
-                    {% endcomment %}
-                </form>
+                </div>
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary btn-small cislc-modalSettings-reset" type="reset">Reset</button>

--- a/src/shared/templates/shared/partial/sidebar_end.html
+++ b/src/shared/templates/shared/partial/sidebar_end.html
@@ -1,9 +1,11 @@
-<div class="sidebar-tool" role="region" aria-label="Reading tools">
+<div class="sidebar-tool" role="region" aria-label="User preferences">
     <button type="button" class="btn btn-setting" aria-label="Settings" title="Settings" data-cfw="modal" data-cfw-modal-target="#modalSettings">
         <span class="icon-settings" aria-hidden="true"></span>
         <span class="sr-only">Settings</span>
     </button>
+</div>
 {% if read_aloud %}
+<div class="sidebar-tts" role="region" aria-label="Text to speech controls">
     {% if read_aloud == 'Readium' %}
     <button type="button" class="btn btn-tool" aria-label="Read aloud" title="Read aloud" id="readiumReadAloud">
     {% else %}
@@ -12,5 +14,5 @@
         <span id="readAloudIcon" class="icon icon-play" aria-hidden="true"></span>
         <span id="readAloudSrText" class="sr-only">Read aloud</span>
     </button>
-{% endif %}
 </div>
+{% endif %}

--- a/src/shared/templates/shared/partial/sidebar_end.html
+++ b/src/shared/templates/shared/partial/sidebar_end.html
@@ -5,14 +5,22 @@
     </button>
 </div>
 {% if read_aloud %}
-<div class="sidebar-tts" role="region" aria-label="Text to speech controls">
-    {% if read_aloud == 'Readium' %}
-    <button type="button" class="btn btn-tool" aria-label="Read aloud" title="Read aloud" id="readiumReadAloud">
-    {% else %}
-    <button type="button" class="btn btn-tool" aria-label="Read aloud" title="Read aloud" id="readAloudButton">
-    {% endif %}
-        <span id="readAloudIcon" class="icon icon-play" aria-hidden="true"></span>
-        <span id="readAloudSrText" class="sr-only">Read aloud</span>
-    </button>
+<div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls"{% if read_aloud == 'Readium' %} data-mode="Readium"{% endif %}>
+    <div class="sidebar-tts-inactive">
+        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+            <span class="icon-play" aria-hidden="true"></span>
+        </button>
+    </div>
+    <div class="sidebar-tts-active">
+        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+            <span class="icon-pause" aria-hidden="true"></span>
+        </button>
+        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+            <span class="icon-play" aria-hidden="true"></span>
+        </button>
+        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+            <span class="icon-stop" aria-hidden="true"></span>
+        </button>
+    </div>
 </div>
 {% endif %}

--- a/src/shared/templates/shared/partial/sidebar_end.html
+++ b/src/shared/templates/shared/partial/sidebar_end.html
@@ -5,20 +5,20 @@
     </button>
 </div>
 {% if read_aloud %}
-<div class="region-tts sidebar-tts" role="region" aria-label="Text to speech controls"{% if read_aloud == 'Readium' %} data-mode="Readium"{% endif %}>
+<div class="tts-region sidebar-tts" role="region" aria-label="Text to speech controls"{% if read_aloud == 'Readium' %} data-mode="Readium"{% endif %}>
     <div class="sidebar-tts-inactive">
-        <button type="button" class="btn btn-tool sidebar-tts-play" aria-label="Read aloud" title="Read aloud">
+        <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud">
             <span class="icon-play" aria-hidden="true"></span>
         </button>
     </div>
     <div class="sidebar-tts-active">
-        <button type="button" class="btn btn-tts sidebar-tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
+        <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud">
             <span class="icon-pause" aria-hidden="true"></span>
         </button>
-        <button type="button" class="btn btn-tts sidebar-tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
+        <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud">
             <span class="icon-play" aria-hidden="true"></span>
         </button>
-        <button type="button" class="btn btn-tts sidebar-tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
+        <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud">
             <span class="icon-stop" aria-hidden="true"></span>
         </button>
     </div>


### PR DESCRIPTION
Adds state swapping for the TTS button in the sidebar, along with Pause and Resume controls.  Works for the most part with the ClusiveTTS, but there does seem to be some lag when using pause/resume, but I don't think there is much we can do there.

Tried to build in support multiple regions of TTS controls, such as a preview one in the settings modal. Does not take into account reading selected text from context menu since it is Reader controlled.

Probably going to need some form of callback from the Reader to update state when play is started or stopped.
