### PR TITLE
CSL-309: Update line height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2735,9 +2735,9 @@
       "dev": true
     },
     "figuration": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/figuration/-/figuration-4.0.1.tgz",
-      "integrity": "sha512-CnT+ACwwDir/lLCcnclBWplZnok2s0GZh3K8ClA5l+rYG6fJtSWvwRCDa5IRaZ7VgR9qTbHUHe9izi6FGSvYJQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/figuration/-/figuration-4.0.2.tgz",
+      "integrity": "sha512-MQtOhNa7pzKzT1q3b98peGpA0LFSBDn0QxYh5ijT9lmSoFz1occgqawhO2v8Omas41Qr/5a5ltmXdsF9QZ2nHw=="
     },
     "figures": {
       "version": "3.2.0",
@@ -5909,9 +5909,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
-      "integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.27",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-webpack": "3.1.3",
     "node-sass": "^4.14.1",
     "postcss": "^8.1.1",
-    "postcss-calc": "^7.0.4",
+    "postcss-calc": "^7.0.5",
     "postcss-flexbugs-fixes": "^4.2.1",
     "source-map-loader": "^1.1.0",
     "stylelint": "^13.7.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@d-i-t-a/reader": "1.2.0-alpha16",
     "expose-loader": "0.7.5",
-    "figuration": "^4.0.1",
+    "figuration": "^4.0.2",
     "fluid-binder": "git+https://github.com/fluid-project/fluid-binder.git#3283b44cd915f8c8c6a432fa60ccc0983ff547b7",
     "gpii-binder": "git+https://github.com/fluid-project/fluid-binder#3283b44cd915f8c8c6a432fa60ccc0983ff547b7",
     "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718.FLUID-6482",

--- a/src/frontend/html/index.html
+++ b/src/frontend/html/index.html
@@ -17,6 +17,7 @@
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/figuration@4.0.0/dist/js/figuration.min.js" integrity="sha384-XqIV+6/aPbInuDsESPata3SBmFPBP6fSRj8dE/LgKX9dkNoGJeLRa8/q9jUo0vW4" crossorigin="anonymous"></script>
+<script src="../js/theme-test.js"></script>
 </head>
 <body>
 

--- a/src/frontend/js/clusive-prefs-modal-settings.js
+++ b/src/frontend/js/clusive-prefs-modal-settings.js
@@ -12,14 +12,14 @@
         },
         mappedValues: {
             modalLineSpacingToPreference: {
-                default: 1.2,
-                tall: 1.6,
-                taller: 2
+                short: 1.2,
+                default: 1.6,
+                tall: 2
             },
             preferenceLineSpaceToModal: {
-                1.2: 'default',
-                1.6: 'tall',
-                2: 'taller'
+                1.2: 'short',
+                1.6: 'default',
+                2: 'tall'
             },
             modalLetterSpacingToPreference: {
                 default: 1,

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -237,8 +237,24 @@ function formRangeTip(range, callback) {
     callback(range);
 }
 
+var updateCSSVars = clusiveDebounce(function() {
+    'use strict';
+
+    //var root = document.documentElement;
+    var body = document.body;
+    var lineHeight = body.style.lineHeight;
+
+    body.style.setProperty('--CT_lineHeight', lineHeight);
+}, 150);
+
+
 $(window).ready(function() {
     'use strict';
+
+    document.addEventListener('update.cisl.prefs', updateCSSVars, {
+        passive: true
+    });
+    updateCSSVars();
 
     formFileText();
     confirmationPublicationDelete();

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -245,7 +245,7 @@ var updateCSSVars = clusiveDebounce(function() {
     var lineHeight = body.style.lineHeight;
 
     body.style.setProperty('--CT_lineHeight', lineHeight);
-}, 150);
+}, 10);
 
 
 $(window).ready(function() {

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -240,7 +240,7 @@ function formRangeTip(range, callback) {
 var updateCSSVars = clusiveDebounce(function() {
     'use strict';
 
-    //var root = document.documentElement;
+    // var root = document.documentElement;
     var body = document.body;
     var lineHeight = body.style.lineHeight;
 

--- a/src/frontend/js/theme-test.js
+++ b/src/frontend/js/theme-test.js
@@ -3,10 +3,16 @@
 function themeControls() {
     'use strict';
 
-    var html = '<div style="position: fixed; bottom: .25rem; left: 50%; z-index: 2000; transform: translateX(-50%); background: #ddd; padding: 0 .5rem; border: 2px solid #666;">';
+    var html = '<div style="position: fixed; bottom: .25rem; left: 50%; z-index: 2000; transform: translateX(-50%); background: #ddd; padding: 0 .5rem; border: 2px solid #666; text-align: center; font-size: .875rem;">';
+    html += 'Theme: ';
     html += '<a href="#" style="color: #009 !important;" onclick="return themeCSS();">Default</a> |';
     html += '<a href="#" style="color: #009 !important;" onclick="return themeCSS(\'sepia\');">Sepia</a> |';
     html += '<a href="#" style="color: #009 !important;" onclick="return themeCSS(\'night\');">Night</a> ';
+    html += '</br>';
+    html += 'Line height: ';
+    html += '<a href="#" style="color: #009 !important;" onclick="return themeLH(1.2);">Short</a> |';
+    html += '<a href="#" style="color: #009 !important;" onclick="return themeLH(1.6);">Default</a> |';
+    html += '<a href="#" style="color: #009 !important;" onclick="return themeLH(2);">Tall</a>';
     html += '</div>';
     $(document.body).append(html);
 }
@@ -27,8 +33,21 @@ function themeCSS(name) {
     return false;
 }
 
+function themeLH(dim) {
+    'use strict';
+
+    if (typeof dim === 'undefined') {
+        dim = 1.6;
+    }
+    document.body.style.lineHeight = dim;
+    document.body.style.setProperty('--CT_lineHeight', dim);
+
+    return false;
+}
+
 $(window).ready(function() {
     'use strict';
 
     themeControls();
+    themeLH();
 });

--- a/src/frontend/scss/clusive.scss
+++ b/src/frontend/scss/clusive.scss
@@ -1,6 +1,9 @@
 // Functions
 @import "../../../node_modules/figuration/scss/functions";
 
+// Clusive specific functions (some mixins too)
+@import "mixins/line-height";
+
 // Settings variables
 @import "site/site-pre";
 @import "../../../node_modules/figuration/scss/settings";

--- a/src/frontend/scss/mixins/_line-height.scss
+++ b/src/frontend/scss/mixins/_line-height.scss
@@ -1,0 +1,12 @@
+// Ouput a `line-height: calc(...)` rule that will allow scalable line-heights
+// Assumes a default `line-height: 1.6` as defined by Infusion
+@mixin calc-line-height($dim) {
+    line-height: calc((#{$dim} / 1.6) * var(--CT_lineHeight));
+}
+
+// Function alternative to the mixin, only returns the `calc(...)` portion
+// Useful for settings overrides
+@function scale-line-height($dim) {
+    $output: calc((#{$dim} / 1.6) * var(--CT_lineHeight));
+    @return $output;
+}

--- a/src/frontend/scss/site/_card.scss
+++ b/src/frontend/scss/site/_card.scss
@@ -25,6 +25,12 @@
     }
 }
 
+.card-body {
+    p:last-child {
+        margin-bottom: 0;
+    }
+}
+
 .card-library {
     box-shadow: var(--CT_cardLibraryBoxShadow);
 

--- a/src/frontend/scss/site/_card.scss
+++ b/src/frontend/scss/site/_card.scss
@@ -55,7 +55,7 @@
     }
 
     .card-body {
-        line-height: 1.375;
+        @include calc-line-height(1.375);
     }
 
     .card-footer {

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -123,7 +123,6 @@ h2,
 
 .has-form-range-tip {
     position: relative;
-    line-height: 1.5;
 }
 .form-range-tip {
     position: absolute;
@@ -255,11 +254,6 @@ h2,
     > li {
         margin-left: 1rem;
     }
-}
-
-// Dropdown menu
-.dropdown-menu {
-    line-height: 1.5;
 }
 
 .media-img {

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -8,6 +8,12 @@
 //     }
 // }
 
+// Use a base value of 1 here since Infusion multiplies the body line-height by the setting value.
+// This allows both Clusive and Readium to use the same line-height as set by Infusion.
+body {
+    --CT_lineHeight: 1;
+}
+
 // stylelint-disable declaration-no-important, selector-max-id
 #ff-default,
 .ff-default {

--- a/src/frontend/scss/site/_footer.scss
+++ b/src/frontend/scss/site/_footer.scss
@@ -15,7 +15,7 @@
 
     .list-horizontal {
         align-items: baseline;
-        line-height: 1.25;
+        @include calc-line-height(1.25);
 
         &.list-divided > .list-item {
             border-color: var(--CT_footerBorderColor);

--- a/src/frontend/scss/site/_goal.scss
+++ b/src/frontend/scss/site/_goal.scss
@@ -1,11 +1,13 @@
 .goal-modal {
     .modal-title {
+        font-family: $goal-modal-title-font-family;
         @include font-size($goal-modal-title-font-size);
         font-style: $goal-modal-title-font-style;
         font-weight: $goal-modal-title-font-weight;
         color: var(--CT_goalModalTitleColor);
     }
     .modal-subtitle {
+        font-family: $goal-modal-subtitle-font-family;
         @include font-size($goal-modal-subtitle-font-size);
         font-style: $goal-modal-subtitle-font-style;
         font-weight: $goal-modal-subtitle-font-weight;

--- a/src/frontend/scss/site/_library.scss
+++ b/src/frontend/scss/site/_library.scss
@@ -23,7 +23,6 @@
     align-items: center;
     padding: .25rem .75rem;
     margin-bottom: 1rem;
-    line-height: $line-height-base;
     color: var(--CT_libraryFilterColor);
     background-color: var(--CT_libraryFilterBg);
     @include border-radius($border-radius);
@@ -42,6 +41,10 @@
         @include hover-focus() {
             text-decoration: underline;
         }
+    }
+
+    @include media-breakpoint-up(sm) {
+        line-height: 1.5;
     }
 }
 

--- a/src/frontend/scss/site/_popover.scss
+++ b/src/frontend/scss/site/_popover.scss
@@ -23,7 +23,7 @@
 }
 
 .popover-header {
-    min-height: calc(#{$popover-header-font-size * $line-height-base} + #{$popover-header-padding-y * 2} + #{$popover-header-border-width});
+    min-height: calc((#{$popover-header-font-size} * #{$line-height-base}) + (#{$popover-header-padding-y} * 2) + #{$popover-header-border-width});
 
     &:empty {
         display: block;

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -30,7 +30,7 @@ $enable-btn-block:                      false;
 $enable-form-control-sizing:            false;
 $enable-form-control-static:            false;
 $enable-form-label-sizing:              false;
-$enable-form-text:                      false;
+$enable-form-text:                      true;
 $enable-form-file:                      true;
 $enable-form-color:                     false;
 $enable-form-row:                       false;

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -166,6 +166,10 @@ $grid-gutter-width:                     2rem;
 
 $border-radius:                         .5rem;
 
+// The CSS variable defined here is set in `_content.scss` so that
+// body line-height is set to 1 for Infusion/Redium consitency
+$line-height-base:                      var(--CT_lineHeight);
+
 $body-bg:                               var(--CT_bodyBg);
 $body-color:                            var(--CT_bodyColor);
 $body-padding-y:                        .625rem;

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -188,6 +188,7 @@ $font-family-sans-serif:                "Source Sans Pro", -apple-system, BlinkM
 $h1-font-size:                          ($font-size-base * 1.375);
 $h2-font-size:                          ($font-size-base * 1.125);
 $h3-font-size:                          ($font-size-base * 1);
+$headings-line-height:                  scale-line-height(1.25);
 
 $text-muted:                            var(--CT_textMuted);
 

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -204,13 +204,14 @@ $table-bg-active:                       var(--CT_tableActiveBg);
 $table-border-color:                    var(--CT_tableBorderColor);
 $table-head-border-width:               5px;
 
-
 $btn-font-weight:                       700;
+$btn-line-height:                       1.5;
 $btn-focus-box-shadow-size:             0 0 0 .1875rem;
 $btn-focus-box-shadow-alpha:            .85;
 //$btn-focus-box-shadow:                  $btn-focus-box-shadow-size rgba(var(--CT_focusRingRGB), $btn-focus-box-shadow-alpha);
 $btn-default-focus-box-shadow-color:    var(--CT_focusRingRGB);
 
+$input-line-height:                     1.5;
 $input-bg:                              #fff;
 $input-focus-box-shadow-size:           0 0 0 .1875rem;
 $input-focus-box-shadow-alpha:          .85;
@@ -402,9 +403,11 @@ $ranking-label-font-size:               .875rem;
 $toc-modal-dialoag-max-width:           22rem;
 $toc-modal-header-border-width:         7px;
 
+$goal-modal-title-font-family:          $font-family-sans-serif;
 $goal-modal-title-font-size:            .875rem;
 $goal-modal-title-font-weight:          400;
 $goal-modal-title-font-style:           italic;
+$goal-modal-subtitle-font-family:       $font-family-sans-serif;
 $goal-modal-subtitle-font-size:         1rem;
 $goal-modal-subtitle-font-weight:       700;
 $goal-modal-subtitle-font-style:        null;

--- a/src/frontend/scss/site/_site.scss
+++ b/src/frontend/scss/site/_site.scss
@@ -1,9 +1,3 @@
-// Opaque color
-// color-get-opaque(rgba(0, 0, 0, .5), #fff) => #808080
-@function color-get-opaque($colorfore, $colorback) {
-    @return mix(rgba($colorfore, 1), $colorback, opacity($colorfore) * 100);
-}
-
 @import "popover";
 @import "modal";
 @import "table";

--- a/src/frontend/scss/site/_wordbank.scss
+++ b/src/frontend/scss/site/_wordbank.scss
@@ -133,8 +133,7 @@
     flex: 1 1 auto;
     align-items: center;
     padding-left: calc(.25rem + 1px);
-    margin: .75rem 0;
-    line-height: 1;
+    margin: .5rem 0;
     white-space: nowrap;
     @include transition(margin-left .25s ease);
 

--- a/src/shared/templates/shared/partial/modal_settings.html
+++ b/src/shared/templates/shared/partial/modal_settings.html
@@ -34,21 +34,21 @@
                                     <legend class="setting-title">Line spacing</legend>
                                     <div class="setting-btn-row">
                                         <div class="btn-check">
-                                            <input id="option-line-height-1" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="default" type="radio">
+                                            <input id="option-line-height-1" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="short" type="radio">
                                             <label for="option-line-height-1" class="btn btn-option" title="Single">
                                                 <span class="icon-line-height-1" aria-hidden="true"></span>
                                                 <span class="sr-only">Single</span>
                                             </label>
                                         </div>
                                         <div class="btn-check">
-                                            <input id="option-line-height-2" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="tall" type="radio" checked>
+                                            <input id="option-line-height-2" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="default" type="radio" checked>
                                             <label for="option-line-height-2" class="btn btn-option" title="Double">
                                                 <span class="icon-line-height-2" aria-hidden="true"></span>
                                                 <span class="sr-only">Double</span>
                                             </label>
                                         </div>
                                         <div class="btn-check">
-                                            <input id="option-line-height-3" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="taller" type="radio">
+                                            <input id="option-line-height-3" name="option-line-height" class="btn-check-input cislc-modalSettings-lineSpacing" value="tall" type="radio">
                                             <label for="option-line-height-3" class="btn btn-option" title="Triple">
                                                 <span class="icon-line-height-3" aria-hidden="true"></span>
                                                 <span class="sr-only">Triple</span>


### PR DESCRIPTION
Normalizes the `line-height` (line spacing) visuals between the Clusive and Readium sides.

Internal names for the line-height have been adjusted to align the `1.6` option as `default`, changing from the `1.2` option marked as such.  I don't think additional changes are needed since `1.6` is the default setting, unless there is a test that needs to be updated.