### PR TITLE
CSL-438: consolidate header scripts into main.js

### DIFF
--- a/src/frontend/js/clusive-context.js
+++ b/src/frontend/js/clusive-context.js
@@ -4,47 +4,52 @@
 Variables and functions for information about the current context
 */
 
-var clusiveContext = {
-    reader: {
-        get window() {
-            var readerIframe = $('#D2Reader-Container').find('iframe');
-            var readerWindow;
-            if (readerIframe.length > 0) {
-                readerWindow = readerIframe[0].contentWindow;            
+var clusiveContext;
+
+$(document).ready(function () { 
+
+    clusiveContext = {
+        reader: {
+            get window() {
+                var readerIframe = $('#D2Reader-Container').find('iframe');
+                var readerWindow;
+                if (readerIframe.length > 0) {
+                    readerWindow = readerIframe[0].contentWindow;            
+                }
+                return readerWindow;
+            },
+            get info() {
+                return getReaderInfo();
+            },
+            get instance() {
+                var readerDefined = typeof D2Reader;
+
+                if (readerDefined !== 'undefined') {
+                    return D2Reader;
+                } return null;
             }
-            return readerWindow;
-        },
-        get info() {
-            return getReaderInfo();
-        },
-        get instance() {
-            var readerDefined = typeof D2Reader;
-
-            if (readerDefined !== 'undefined') {
-                return D2Reader;
-            } return null;
-        }
-    }    
-}
-
-var getReaderInfo = function () {
-    var readerInfo = {};
-    if(clusiveContext.reader.window) {        
-        // Include info from the HTML document
-        readerInfo.document = {};
-        readerInfo.document.title = clusiveContext.reader.window.document.title;
-        readerInfo.document.baseURI = clusiveContext.reader.window.document.baseURI;
-        // Include info from variables in reader.html
-        readerInfo.publication = {};
-        if(pub_id) {
-            readerInfo.publication.id = pub_id;
-        }
-        if(pub_version) {
-            readerInfo.publication.version = pub_version;
-        }
-        if(manifest_path) {
-            readerInfo.publication.manifestPath = manifest_path;
-        }
+        }    
     }
-    return readerInfo;    
-}
+
+    var getReaderInfo = function () {
+        var readerInfo = {};
+        if(clusiveContext.reader.window) {        
+            // Include info from the HTML document
+            readerInfo.document = {};
+            readerInfo.document.title = clusiveContext.reader.window.document.title;
+            readerInfo.document.baseURI = clusiveContext.reader.window.document.baseURI;
+            // Include info from variables in reader.html
+            readerInfo.publication = {};
+            if(pub_id) {
+                readerInfo.publication.id = pub_id;
+            }
+            if(pub_version) {
+                readerInfo.publication.version = pub_version;
+            }
+            if(manifest_path) {
+                readerInfo.publication.manifestPath = manifest_path;
+            }
+        }
+        return readerInfo;    
+    }
+});

--- a/src/frontend/js/clusive-context.js
+++ b/src/frontend/js/clusive-context.js
@@ -4,11 +4,10 @@
 Variables and functions for information about the current context
 */
 
-var clusiveContext;
 
 $(document).ready(function () { 
 
-    clusiveContext = {
+    window.clusiveContext = {
         reader: {
             get window() {
                 var readerIframe = $('#D2Reader-Container').find('iframe');

--- a/src/frontend/js/clusive-events-caliper.js
+++ b/src/frontend/js/clusive-events-caliper.js
@@ -10,41 +10,43 @@ var addControlInteractionToQueue = function (control, value) {
     });
 };
 
-var clusiveEvents = {
-    messageQueue: clusive.djangoMessageQueue(),    
-    caliperEventTypes: {
-        TOOL_USE_EVENT: "TOOL_USE_EVENT"
-    },    
-    trackedControlInteractions: [
-        {
-            selector: ".btn.tts-play",
-            handler: "click",
-            control: "tts-play",
-            value: "clicked"
-        },
-        {
-            selector: ".btn.tts-pause",
-            handler: "click",
-            control: "tts-pause",
-            value: "clicked"
-        },
-        {
-            selector: ".btn.tts-resume",
-            handler: "click",
-            control: "tts-resume",
-            value: "clicked"
-        },
-        {
-            selector: ".btn.tts-stop",
-            handler: "click",
-            control: "tts-stop",
-            value: "clicked"
-        }         
-    ],
-    addControlInteractionToQueue: addControlInteractionToQueue    
-}
+var clusiveEvents;
 
 $(document).ready(function () {    
+
+    clusiveEvents = {
+        messageQueue: clusive.djangoMessageQueue(),    
+        caliperEventTypes: {
+            TOOL_USE_EVENT: "TOOL_USE_EVENT"
+        },    
+        trackedControlInteractions: [
+            {
+                selector: ".btn.tts-play",
+                handler: "click",
+                control: "tts-play",
+                value: "clicked"
+            },
+            {
+                selector: ".btn.tts-pause",
+                handler: "click",
+                control: "tts-pause",
+                value: "clicked"
+            },
+            {
+                selector: ".btn.tts-resume",
+                handler: "click",
+                control: "tts-resume",
+                value: "clicked"
+            },
+            {
+                selector: ".btn.tts-stop",
+                handler: "click",
+                control: "tts-stop",
+                value: "clicked"
+            }         
+        ],
+        addControlInteractionToQueue: addControlInteractionToQueue    
+    }
 
     // Build additional control interaction objects here from any data-clusive-event attributes on page markup
     // synax: data-clusive-event="[handler]|[control]|[value]"

--- a/src/frontend/js/clusive-events-caliper.js
+++ b/src/frontend/js/clusive-events-caliper.js
@@ -1,20 +1,18 @@
 'use strict'
 
-var addControlInteractionToQueue = function (control, value) {    
-    console.debug("Adding control interaction to queue: ", control, value)
-    clusiveEvents.messageQueue.add({
-        "type": "CE", 
-        "caliperEvent": {"type": clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, "control": control, "value": value},
-        "readerInfo": clusiveContext.reader.info,
-        "eventId": PAGE_EVENT_ID
-    });
-};
-
-var clusiveEvents;
-
 $(document).ready(function () {    
 
-    clusiveEvents = {
+    var addControlInteractionToQueue = function (control, value) {    
+        console.debug("Adding control interaction to queue: ", control, value)
+        clusiveEvents.messageQueue.add({
+            "type": "CE", 
+            "caliperEvent": {"type": clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, "control": control, "value": value},
+            "readerInfo": clusiveContext.reader.info,
+            "eventId": PAGE_EVENT_ID
+        });
+    };
+
+    window.clusiveEvents = {
         messageQueue: clusive.djangoMessageQueue(),    
         caliperEventTypes: {
             TOOL_USE_EVENT: "TOOL_USE_EVENT"

--- a/src/frontend/js/page-timing.js
+++ b/src/frontend/js/page-timing.js
@@ -161,4 +161,7 @@ PageTiming.isTimingSupported = function() {
     }
 };
 
-PageTiming.trackPage(PAGE_EVENT_ID);
+$(document).ready(function () {
+    PageTiming.trackPage(PAGE_EVENT_ID);
+});
+

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-use-before-define */
 /* global D2Reader */
 
-var clusiveTTS = {
+window.clusiveTTS = {
     synth: window.speechSynthesis,
     elementsToRead: [],
     region: {},
@@ -474,7 +474,7 @@ clusiveTTS.readAloudSample = function() {
     window.speechSynthesis.speak(utt);
 };
 
-var clusiveSelection = {
+window.clusiveSelection = {
     directions: {
         FORWARD: 'Forward',
         BACKWARD: 'Backward',

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,9 @@ import execFiguration from 'script-loader!figuration';
 import execGPIIBinder from "script-loader!gpii-binder/src/js/binder.js";
 
 // import execMarkJs from 'script-loader!mark.js';
+import execClusiveContext from "script-loader!../src/frontend/js/clusive-context.js";
+import execClusiveEventsCaliper from "script-loader!../src/frontend/js/clusive-events-caliper.js"
 
-// import execClusiveContext from "script-loader!../src/frontend/js/clusive-context.js";
-// import execClusiveEventsCaliper from "script-loader!../src/frontend/js/clusive-events-caliper.js"
 import execClusiveReaderPrefs from "script-loader!../src/frontend/js/clusive-reader-prefs.js";
 import execClusivePrefsPanel from "script-loader!../src/frontend/js/clusive-prefs-panel.js";
 import execClusiveMessageQueue from "script-loader!../src/frontend/js/clusive-message-queue.js"

--- a/src/index.js
+++ b/src/index.js
@@ -24,3 +24,20 @@ import execFiguration from 'script-loader!figuration';
 import execGPIIBinder from "script-loader!gpii-binder/src/js/binder.js";
 
 // import execMarkJs from 'script-loader!mark.js';
+
+// import execClusiveContext from "script-loader!../src/frontend/js/clusive-context.js";
+// import execClusiveEventsCaliper from "script-loader!../src/frontend/js/clusive-events-caliper.js"
+import execClusiveReaderPrefs from "script-loader!../src/frontend/js/clusive-reader-prefs.js";
+import execClusivePrefsPanel from "script-loader!../src/frontend/js/clusive-prefs-panel.js";
+import execClusiveMessageQueue from "script-loader!../src/frontend/js/clusive-message-queue.js"
+import execClusiveDjangoMessageQueue from "script-loader!../src/frontend/js/clusive-django-message-queue.js"
+import execClusivePrefsDjangoStore from "script-loader!../src/frontend/js/clusive-prefs-django-store.js"
+import execClusivePrefsModalSettings from "script-loader!../src/frontend/js/clusive-prefs-modal-settings.js"
+import execFrontEnd from "script-loader!../src/frontend/js/frontend.js"
+import execGlossary from "script-loader!../src/frontend/js/glossary.js"
+import execImages from "script-loader!../src/frontend/js/images.js"
+import execPageTiming from "script-loader!../src/frontend/js/page-timing.js"
+
+import execToC from "script-loader!../src/frontend/js/toc.js";
+import execTTS from "script-loader!../src/frontend/js/tts.js";
+import execWhy from "script-loader!../src/frontend/js/why.js";

--- a/src/shared/templates/shared/partial/head_scripts.html
+++ b/src/shared/templates/shared/partial/head_scripts.html
@@ -20,22 +20,9 @@ var clusivePrefs;
 </script>
 
 <script src="{% static 'shared/js/lib/main.js' %}"></script>
-<script src="{% static 'shared/js/clusive-context.js' %}"></script>
-<script src="{% static 'shared/js/clusive-reader-prefs.js' %}"></script>
-<script src="{% static 'shared/js/clusive-message-queue.js' %}"></script>
-<script src="{% static 'shared/js/clusive-django-message-queue.js' %}"></script>
-<script src="{% static 'shared/js/clusive-events-caliper.js' %}"></script>
-<script src="{% static 'shared/js/clusive-prefs-django-store.js' %}"></script>
-<script src="{% static 'shared/js/clusive-prefs-panel.js' %}"></script>
-<script src="{% static 'shared/js/clusive-prefs-modal-settings.js' %}"></script>
 
-<script src="{% static 'shared/js/frontend.min.js' %}"></script>
-<script src="{% static 'shared/js/glossary.js' %}"></script>
-<script src="{% static 'shared/js/images.js' %}"></script>
-<script src="{% static 'shared/js/page-timing.js' %}"></script>
-<script src="{% static 'shared/js/toc.js' %}"></script>
-<script src="{% static 'shared/js/tts.js' %}"></script>
-<script src="{% static 'shared/js/why.js' %}"></script>
+<script src="{% static 'shared/js/clusive-context.js' %}"></script>
+<script src="{% static 'shared/js/clusive-events-caliper.js' %}"></script>
 
 <script>
 {% if settings.DEBUG %}

--- a/src/shared/templates/shared/partial/head_scripts.html
+++ b/src/shared/templates/shared/partial/head_scripts.html
@@ -21,9 +21,6 @@ var clusivePrefs;
 
 <script src="{% static 'shared/js/lib/main.js' %}"></script>
 
-<script src="{% static 'shared/js/clusive-context.js' %}"></script>
-<script src="{% static 'shared/js/clusive-events-caliper.js' %}"></script>
-
 <script>
 {% if settings.DEBUG %}
     var debug = true;


### PR DESCRIPTION
This moves all current scripts into the Webpack-generated main.js file.

Due to Webpack's conventions, this required some minimal refactoring to explicitly place some referenced globals on the `window` object, and wrap some code execution in `$(document).ready()` to avoid reliance on script load order.