### PR TITLE
Various event logging JIRAs

### DIFF
--- a/src/eventlog/signals.py
+++ b/src/eventlog/signals.py
@@ -126,6 +126,9 @@ def create_event(kwargs, control=None, value=None, action='USED', event_type='TO
                         value=value,
                         **common_event_args)                      
     if event:
+        # TODO: this doesn't validate the object by the rules like 
+        # limited choices for ACTION and TYPE based on Caliper's spec
+        # See https://docs.djangoproject.com/en/3.1/ref/models/instances/#validating-objects
         event.save()
 
 # word_rated = Signal(providing_args=['request', 'event_id', 'word', 'rating'])

--- a/src/eventlog/signals.py
+++ b/src/eventlog/signals.py
@@ -20,7 +20,7 @@ page_timing = Signal(providing_args=['event_id', 'times'])
 vocab_lookup = Signal(providing_args=['request', 'word', 'cued', 'source'])
 preference_changed = Signal(providing_args=['request', 'event_id', 'preference', 'timestamp', 'reader_info'])
 annotation_action = Signal(providing_args=['request', 'action', 'annotation'])
-control_used = Signal(providing_args=['request', 'event_id', 'control', 'value', 'timestamp', 'reader_info'])
+control_used = Signal(providing_args=['request', 'event_id', 'control', 'value', 'event_type', 'action', 'timestamp', 'reader_info'])
 word_rated = Signal(providing_args=['request', 'event_id', 'word', 'rating'])
 
 #
@@ -118,8 +118,8 @@ def get_common_event_args(kwargs):
 
 # General function for event creation
 # Defaults action and type to the most common TOOL_USE_EVENT type
-def create_event(kwargs, control=None, value=None, action='USED', event_type='TOOL_USE_EVENT'):    
-    common_event_args = get_common_event_args(kwargs)            
+def create_event(kwargs, control=None, value=None, action='USED', event_type='TOOL_USE_EVENT'):
+    common_event_args = get_common_event_args(kwargs)
     event = Event.build(type=event_type,                        
                         action=action,
                         control=control,
@@ -152,8 +152,10 @@ def log_vocab_lookup(sender, **kwargs):
 def log_control_used(sender, **kwargs):
     """User interacts with a control"""        
     control = kwargs.get('control')
-    value = kwargs.get('value')             
-    create_event(kwargs, control=control, value=value)
+    value = kwargs.get('value')
+    event_type = kwargs.get('event_type') 
+    action = kwargs.get('action')
+    create_event(kwargs, control=control, value=value, action=action, event_type=event_type)
 
 @receiver(preference_changed)
 def log_pref_change(sender, **kwargs):

--- a/src/frontend/js/clusive-events-caliper.js
+++ b/src/frontend/js/clusive-events-caliper.js
@@ -29,6 +29,17 @@ $(document).ready(function() {
         });
     };
     
+
+    var trackControlInteraction = function(interactionDef) {
+        console.debug('Setting up control tracking for: ', interactionDef)
+        var control = $(interactionDef.selector);
+        console.debug('Event for control tracking: ', interactionDef, control);
+        var handler = interactionDef.handler;
+        $(interactionDef.selector)[handler](function() {
+            addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, interactionDef.control, interactionDef.value, window.clusiveEvents.caliperEventActions.USED);
+        });
+    };
+
     window.clusiveEvents = {        
         messageQueue: clusive.djangoMessageQueue({
             config: {
@@ -49,7 +60,7 @@ $(document).ready(function() {
             CONTROL: 'data-cle-control',
             VALUE: 'data-cle-value'
         },
-        trackedControlInteractions: [
+        controlInteractionsToTrack: [
             /*
                 control interactions to track can be added centrally here if needed,
                 but in most cases using the data-cle-* attributes on the markup
@@ -64,7 +75,9 @@ $(document).ready(function() {
         ],
         addCaliperEventToQueue: addCaliperEventToQueue,
         addTipRelatedActionToQueue: addTipRelatedActionToQueue,
-        addVocabCheckSkippedEventToQueue: addVocabCheckSkippedEventToQueue
+        addVocabCheckSkippedEventToQueue: addVocabCheckSkippedEventToQueue,
+        trackControlInteraction: trackControlInteraction
+
     };
 
     // Build additional control interaction objects here from any data-clusive-event attributes on page markup
@@ -84,20 +97,15 @@ $(document).ready(function() {
                 control: eventControl,
                 value: eventValue
             };
-            clusiveEvents.trackedControlInteractions.push(interactionDef);
+            clusiveEvents.controlInteractionsToTrack.push(interactionDef);
         } else {
             console.debug('tried to add event logging, but missing a needed data-cle-* attribute on the element: ', elm);
         }
     });
-
+    
     // Set up events control interactions here
-    clusiveEvents.trackedControlInteractions.forEach(function(interactionDef) {
-        var control = $(interactionDef.selector);
-        console.debug('Event for control tracking: ', interactionDef, control);
-        var handler = interactionDef.handler;
-        $(interactionDef.selector)[handler](function() {
-            addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, interactionDef.control, interactionDef.value, window.clusiveEvents.caliperEventActions.USED);
-        });
+    clusiveEvents.controlInteractionsToTrack.forEach(function(interactionDef) {
+        clusiveEvents.trackControlInteraction(interactionDef);
     });
 
     $('body').on('click', '*[data-clusive-tip-action]', function(event) {

--- a/src/frontend/js/clusive-events-caliper.js
+++ b/src/frontend/js/clusive-events-caliper.js
@@ -3,14 +3,15 @@
 $(document).ready(function() {
     'use strict';
 
-    var addCaliperEventToQueue = function(eventType, control, value) {
+    var addCaliperEventToQueue = function(eventType, control, value, action) {
         console.debug('Adding caliper event to queue: ', eventType, control, value);
         window.clusiveEvents.messageQueue.add({
             type: 'CE',
             caliperEvent: {
                 type: eventType,
                 control: control,
-                value: value
+                value: value,
+                action: action
             },
             readerInfo: clusiveContext.reader.info,
             eventId: PAGE_EVENT_ID
@@ -18,7 +19,7 @@ $(document).ready(function() {
     };
 
     var addVocabCheckSkippedEventToQueue = function() {
-        window.clusiveEvents.addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.ASSESSMENT_ITEM_EVENT, 'word_rating', 'SKIPPED')
+        window.clusiveEvents.addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.ASSESSMENT_ITEM_EVENT, 'word_rating', null, window.clusiveEvents.caliperEventActions.ASSESSMENT_ITEM_SKIPPED)
     }
 
     var addTipRelatedActionToQueue = function(action) {
@@ -37,6 +38,11 @@ $(document).ready(function() {
         caliperEventTypes: {
             TOOL_USE_EVENT: 'TOOL_USE_EVENT',
             ASSESSMENT_ITEM_EVENT: 'ASSESSMENT_ITEM_EVENT'
+        },
+        caliperEventActions: {
+            USED: "USED",
+            ASSESSMENT_ITEM_SKIPPED: "SKIPPED",
+            ASSESSMENT_ITEM_COMPLETED: "COMPLETED",
         },
         dataAttributes: {
             HANDLER: 'data-cle-handler',
@@ -90,7 +96,7 @@ $(document).ready(function() {
         console.debug('Event for control tracking: ', interactionDef, control);
         var handler = interactionDef.handler;
         $(interactionDef.selector)[handler](function() {
-            addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, interactionDef.control, interactionDef.value);
+            addCaliperEventToQueue(window.clusiveEvents.caliperEventTypes.TOOL_USE_EVENT, interactionDef.control, interactionDef.value, window.clusiveEvents.caliperEventActions.USED);
         });
     });
 

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -153,7 +153,7 @@ function buildTableOfContents() {
                     var interactionDef = {
                         selector: elem,
                         handler: "click",
-                        control: "reader-navigation",
+                        control: "reader-navigation-toc",
                         value: "toc-nav-link:" + $(elem).attr("href")
                     };                    
                     clusiveEvents.trackControlInteraction(interactionDef);
@@ -262,6 +262,19 @@ function buildAnnotationList() {
     return $.get('/library/annotationlist/' + window.pub_id + '/' + window.pub_version)
         .done(function(data) {
             $annotationsContainer.html(data);
+            // Add tracking events for using annotation navigation
+            $annotationsContainer.find('.goto-highlight').each(function (i, elem) {
+                var annotationId = $(elem).parent("div").attr("data-annotation-id");
+
+                var interactionDef = {                
+                    selector: elem,
+                    handler: "click",
+                    control: "reader-navigation-annotation",
+                    value: "annotation-nav-link:" + annotationId
+                };           
+
+                clusiveEvents.trackControlInteraction(interactionDef);
+            });
         })
         .fail(function(err) {
             console.error(err);

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -138,19 +138,31 @@ function buildTableOfContents() {
                 var out = buildTocLevel(items, 0, 'toc');
                 $(TOC_CONTAINER).html(out).CFW_Init();
 
+                var navLinks = $(TOC_CONTAINER).find('.nav-link');
                 // Add click event to update menu when new page selected
-                $(TOC_CONTAINER).find('.nav-link').on('click', function() {
+                navLinks.on('click', function() {
                     // Use timeout delay until we can get a callback from reader
                     setTimeout(function() {
                         resetCurrentTocItem(false);
                         markTocItemActive();
                     }, 100);
                 });
+                // Attach tracking events after markup is built
+                navLinks.each(function (i, elem) {
+                    console.debug("adding tracking for navLink", elem)
+                    var interactionDef = {
+                        selector: elem,
+                        handler: "click",
+                        control: "reader-navigation",
+                        value: "toc-nav-link:" + $(elem).attr("href")
+                    };                    
+                    clusiveEvents.trackControlInteraction(interactionDef);
+                });
             } else {
                 // Empty TOC
                 $(TOC_CONTAINER).hide();
             }
-        });
+        });        
     }
 }
 

--- a/src/glossary/templates/glossary/glossdef.html
+++ b/src/glossary/templates/glossary/glossdef.html
@@ -15,14 +15,24 @@
 {% for m in defs.meanings %}
     {% for img in m.images %}
         <figure class="figure">
-            <img class="figure-img img-fluid" src="{% get_media_prefix %}{{book_path}}/{{img.src}}" alt="{{img.alt}}" />
+            <img class="figure-img img-fluid" src="{% get_media_prefix %}{{book_path}}/{{img.src}}" alt="{{img.alt}}" />            
             <div class="figure-caption">
                 {{img.caption}}
                 {% if img.description %}
-                <details>
+                <details class="definition-details">
                     <summary>details</summary>
                     <p>{{img.description}}</p>
                 </details>
+                <script>
+                    var detailsElem = $(".definition-details");
+                    var interactionDef = {
+                        selector: detailsElem,
+                        handler: "click",
+                        control: "glossary-image-description:probe",
+                        value: "opened"
+                    };                    
+                    clusiveEvents.trackControlInteraction(interactionDef);
+                </script>
                 {% endif %}
             </div>
         </figure>

--- a/src/glossary/templates/glossary/glossdef.html
+++ b/src/glossary/templates/glossary/glossdef.html
@@ -28,7 +28,7 @@
                     var interactionDef = {
                         selector: detailsElem,
                         handler: "click",
-                        control: "glossary-image-description:probe",
+                        control: "glossary-image-description:{{defs.headword}}",
                         value: "opened"
                     };                    
                     clusiveEvents.trackControlInteraction(interactionDef);

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -46,9 +46,10 @@ class Message:
         event_type = self.content['caliperEvent']['type']
         control = self.content['caliperEvent']['control']
         value = self.content['caliperEvent']['value']
+        action = self.content['caliperEvent']['action']
         reader_info = self.content['readerInfo']
         control_used.send(sender=self.__class__, timestamp=self.timestamp,
-                          request=self.request, event_id = event_id, type=event_type, control=control, value=value, reader_info=reader_info)
+                          request=self.request, event_id = event_id, event_type=event_type, control=control, value=value, action=action, reader_info=reader_info)
 
     def send_page_timing(self):
         event_id = self.content['eventId']

--- a/src/pages/templates/pages/wordbank.html
+++ b/src/pages/templates/pages/wordbank.html
@@ -58,9 +58,9 @@
                 {% for wm in words %}
                     <div data-rating="{{wm.knowledge_est}}" class="wordbank-item offset{{wm.knowledge_est}}">
                         <a href="#" role="button" class="wordbank-word" aria-describedby="rank{{wm.knowledge_est}}">{{wm.word}}</a>
-                        <a href="#" role="button" class="wordbank-prev" aria-label="Decrease rating for '{{wm.word}}'" title="Move left"><span class="icon-chevron-left" aria-hidden="true"></span><span class="sr-only">Decrease rating for '{{wm.word}}'</span></a>
-                        <a href="#" role="button" class="wordbank-next" aria-label="Increase rating for '{{wm.word}}'" title="Move right"><span class="icon-chevron-right" aria-hidden="true"></span><span class="sr-only">Increase rating for '{{wm.word}}'</span></a>
-                        <a href="#" role="button" class="wordbank-del" aria-label="Remove '{{wm.word}}' from word bank" title="Remove"><span class="icon-cancel" aria-hidden="true"></span><span class="sr-only">Remove '{{wm.word}}' from word bank</span></a>
+                        <a href="#" role="button" class="wordbank-prev" aria-label="Decrease rating for '{{wm.word}}'" title="Move left" data-cle-handler="click" data-cle-control="wordbank-shift" data-cle-value="shift-left:{{wm.word}}"><span class="icon-chevron-left" aria-hidden="true"></span><span class="sr-only">Decrease rating for '{{wm.word}}'</span></a>
+                        <a href="#" role="button" class="wordbank-next" aria-label="Increase rating for '{{wm.word}}'" title="Move right"><span class="icon-chevron-right" aria-hidden="true" data-cle-handler="click" data-cle-control="wordbank-shift" data-cle-value="shift-right:{{wm.word}}"></span><span class="sr-only">Increase rating for '{{wm.word}}'</span></a>
+                        <a href="#" role="button" class="wordbank-del" aria-label="Remove '{{wm.word}}' from word bank" title="Remove" data-cle-handler="click" data-cle-control="wordbank-shift" data-cle-value="remove:{{wm.word}}"><span class="icon-cancel" aria-hidden="true"></span><span class="sr-only">Remove '{{wm.word}}' from word bank</span></a>
                     </div>
                 {% endfor %}
                 </div>

--- a/src/shared/templates/shared/partial/modal_toc.html
+++ b/src/shared/templates/shared/partial/modal_toc.html
@@ -8,8 +8,8 @@
                     <span class="icon-cancel" aria-hidden="true"></span>
                 </button>
                 <ul class="nav nav-tabs-toc">
-                    <li class="nav-item"><a id="tocTab" href="#tocPanel" class="nav-link" data-cfw="tab">Contents</a></li>
-                    <li class="nav-item"><a id="notesTab" href="#notesPanel" class="nav-link" data-cfw="tab">Highlights &amp; Notes</a></li>
+                    <li class="nav-item"><a id="tocTab" href="#tocPanel" class="nav-link" data-cfw="tab" data-cle-handler="click" data-cle-control="toc-sidebar-contents-tab" data-cle-value="opened">Contents</a></li>
+                    <li class="nav-item"><a id="notesTab" href="#notesPanel" class="nav-link" data-cfw="tab" data-cle-handler="click" data-cle-control="toc-sidebar-highlights-and-notes-tab" data-cle-value="opened">Highlights &amp; Notes</a></li>
                 </ul>
             </div>
             <div class="modal-body">

--- a/src/shared/templates/shared/partial/modal_why.html
+++ b/src/shared/templates/shared/partial/modal_why.html
@@ -18,7 +18,7 @@
                     {% if prev_version %}
                     <div class="col-sm-4 why-level-item">
                         <span class="icon-walk why-icon" aria-hidden="true"></span>
-                        <a href="{{ prev_version }}" class="btn btn-primary btn-small"><span class="aria-hidden"></span> Less Challenge</a>
+                        <a href="{{ prev_version }}" class="btn btn-primary btn-small" data-cle-handler="click" data-cle-control="why-am-i-seeing-this-document-level" data-cle-value="less-challenge"><span class="aria-hidden"></span> Less Challenge</a>
                     </div>
                     {% else %}
                      <div class="col-sm-4 why-level-item disabled" title="No more levels this way">
@@ -29,12 +29,12 @@
                     <div class="col-sm-4 why-level-item">
                         <span class="icon-hike why-icon active" aria-hidden="true"></span>
                         <span class="small">(you are here)</span>
-                        <a href="#" class="btn btn-primary btn-small" data-cfw-dismiss="modal">Stay here</a>
+                        <a href="#" class="btn btn-primary btn-small" data-cfw-dismiss="modal" data-cle-handler="click" data-cle-control="why-am-i-seeing-this-document-level" data-cle-value="stay-here">Stay here</a>
                     </div>
                     {% if next_version %}
                     <div class="col-sm-4 why-level-item">
                         <span class="icon-climb why-icon" aria-hidden="true"></span>
-                        <a href="{{ next_version }}" class="btn btn-primary btn-small">More challenge <span class="aria-hidden"></span></a>
+                        <a href="{{ next_version }}" class="btn btn-primary btn-small" data-cle-handler="click" data-cle-control="why-am-i-seeing-this-document-level" data-cle-value="more-challenge">More challenge <span class="aria-hidden"></span></a>
                     </div>
                     {% else %}
                     <div class="col-sm-4 why-level-item disabled" title="No more levels this way">

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -1,6 +1,6 @@
 {% if nav %}
 <nav class="sidebar-nav" aria-label="Article">
-    <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="toc-highlights-notes-sidebar" data-cle-value="opened">
+    <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="contents-highlights-notes-sidebar" data-cle-value="opened">
         <span class="icon-th-list" aria-hidden="true"></span>
     </button>
     <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page">

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -13,7 +13,7 @@
 {% endif %}
 {% if why %}
 <div class="sidebar-support" role="region" aria-label="Support">
-    <button id="whyButton" type="button" class="btn btn-nav btn-icon btn-support-help" aria-label="Why am I seeing this version of the text?!" title="Why am I seeing this version of the text?!">
+    <button id="whyButton" type="button" class="btn btn-nav btn-icon btn-support-help" aria-label="Why am I seeing this version of the text?!" title="Why am I seeing this version of the text?!" data-cle-handler="click" data-cle-control="why-am-i-seeing-this-modal" data-cle-value="opened">
         <span class="icon-help" aria-hidden="true"></span>
         <span class="icon-attention" aria-hidden="true"></span>
     </button>

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -1,6 +1,6 @@
 {% if nav %}
 <nav class="sidebar-nav" aria-label="Article">
-    <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes">
+    <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="toc-highlights-notes-sidebar" data-cle-value="opened">
         <span class="icon-th-list" aria-hidden="true"></span>
     </button>
     <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page">

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -3,10 +3,10 @@
     <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="contents-highlights-notes-sidebar" data-cle-value="opened">
         <span class="icon-th-list" aria-hidden="true"></span>
     </button>
-    <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page">
+    <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page" data-cle-handler="click" data-cle-control="reader-navigation" data-cle-value="previous-page">
         <span class="icon-chevron-left" aria-hidden="true"></span>
     </button>
-    <button id="nextResourceButton" onclick="D2Reader.nextPage();" type="button" class="btn btn-nav btn-icon btn-nav-next" aria-label="Next page" title="Next page">
+    <button id="nextResourceButton" onclick="D2Reader.nextPage();" type="button" class="btn btn-nav btn-icon btn-nav-next" aria-label="Next page" title="Next page" data-cle-handler="click" data-cle-control="reader-navigation" data-cle-value="next-page">
         <span class="icon-chevron-right" aria-hidden="true"></span>
     </button>
 </nav>

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -3,10 +3,10 @@
     <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="contents-highlights-notes-sidebar" data-cle-value="opened">
         <span class="icon-th-list" aria-hidden="true"></span>
     </button>
-    <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page" data-cle-handler="click" data-cle-control="reader-navigation" data-cle-value="previous-page">
+    <button id="prevResourceButton" onclick="D2Reader.previousPage();" type="button" class="btn btn-nav btn-icon btn-nav-prev" aria-label="Previous page" title="Previous page" data-cle-handler="click" data-cle-control="reader-navigation-pagination" data-cle-value="previous-page">
         <span class="icon-chevron-left" aria-hidden="true"></span>
     </button>
-    <button id="nextResourceButton" onclick="D2Reader.nextPage();" type="button" class="btn btn-nav btn-icon btn-nav-next" aria-label="Next page" title="Next page" data-cle-handler="click" data-cle-control="reader-navigation" data-cle-value="next-page">
+    <button id="nextResourceButton" onclick="D2Reader.nextPage();" type="button" class="btn btn-nav btn-icon btn-nav-next" aria-label="Next page" title="Next page" data-cle-handler="click" data-cle-control="reader-navigation-pagination" data-cle-value="next-page">
         <span class="icon-chevron-right" aria-hidden="true"></span>
     </button>
 </nav>


### PR DESCRIPTION
This PR handles the addition of event tracking for a number of JIRAs that are child issues of the main CSL-350 event logging JIRA at https://castudl.atlassian.net/browse/CSL-350

Specifically, it should address:
- https://castudl.atlassian.net/browse/CSL-355
- https://castudl.atlassian.net/browse/CSL-356
- https://castudl.atlassian.net/browse/CSL-365
- https://castudl.atlassian.net/browse/CSL-366
- https://castudl.atlassian.net/browse/CSL-367
- https://castudl.atlassian.net/browse/CSL-368
- https://castudl.atlassian.net/browse/CSL-369
- https://castudl.atlassian.net/browse/CSL-370
- https://castudl.atlassian.net/browse/CSL-371

In some cases these were a straightforward matter of using the `data-cle-*`  annotation style to add event logging to markup that is available when the page loads, but I've also done some light refactoring of the client-side event logging code to make it easier to add event logging as part of the flow of generating HTML dynamically after the page is loaded - CSL-363, CSL-368 and CSL-370 should show the general approach to this.