### PR TITLE
NOJIRA: Added note about not using python 3.9.x

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,9 @@ To try it out quickly using Docker skip ahead to that section.
 ### Prerequisites
 
 * [Python 3](https://www.python.org/downloads/)
-  * Version 3.7.4 or later. On Mac, Homebrew is the easiest way to install.
+  * Version 3.7.4 or later, but less than 3.9. On Mac, Homebrew is the easiest way to install.
+  * Note: Version 3.9 removes member `tp_print` from `PyTypeObject` which is
+    used by some of Clusive's dependencies; see "[What’s New In Python 3.9](https://docs.python.org/3.9/whatsnew/3.9.html#id3)".
 * [virtualenv](https://virtualenv.pypa.io/en/latest/) 
   * Not required, but highly recommended for maintaining an isolated environment and dependencies.
 * [Postgres](https://www.postgresql.org/) 


### PR DESCRIPTION
Small change to `INSTALL.md` warning users to not use python version 3.9 or higher.
