### PR TITLE
bugfix/CSL-721: not all queues being flushed on logout as intended

### DIFF
--- a/src/frontend/js/clusive-django-message-queue.js
+++ b/src/frontend/js/clusive-django-message-queue.js
@@ -3,16 +3,16 @@
 (function(fluid) {
     'use strict';
 
-    fluid.defaults("clusive.logoutFlushRecorder", {
+    fluid.defaults("clusive.logoutFlushManager", {
         gradeNames: ["fluid.component", "fluid.resolveRootSingle"],
-        singleRootType: "clusive.logoutFlushRecorder",
+        singleRootType: "clusive.logoutFlushManager",
         members: {
             numberOfQueues: 0,
             completedFlushes: 0
         }
     });
 
-    var logoutFlushRecorder = clusive.logoutFlushRecorder();
+    var logoutFlushManager = clusive.logoutFlushManager();
 
     // Message queue implementation to work with the Django store
     fluid.defaults("clusive.djangoMessageQueue", {
@@ -29,7 +29,7 @@
             logoutLinkSelector: "#logoutLink"
         },
         components: {
-            logoutFlushRecorder: "{logoutFlushRecorder}"
+            logoutFlushManager: "{logoutFlushManager}"
         },
         events: {
             logoutFlushComplete: null
@@ -68,9 +68,9 @@
                 funcName: "clusive.djangoMessageQueue.attachLogoutEvents",
                 args: ["{that}"]
             },
-            "onCreate.registerWithLogoutFlushRecorder": {
-                funcName: "clusive.djangoMessageQueue.registerWithLogoutFlushRecorder",
-                args: ["{logoutFlushRecorder}"]
+            "onCreate.registerWithlogoutFlushManager": {
+                funcName: "clusive.djangoMessageQueue.registerWithlogoutFlushManager",
+                args: ["{logoutFlushManager}"]
             },
             "logoutFlushComplete.doLogout": {
                 funcName: "clusive.djangoMessageQueue.doLogout",
@@ -79,8 +79,8 @@
         }
     });
 
-    clusive.djangoMessageQueue.registerWithLogoutFlushRecorder = function (logoutFlushRecorder) {
-        logoutFlushRecorder.numberOfQueues = logoutFlushRecorder.numberOfQueues+1;
+    clusive.djangoMessageQueue.registerWithlogoutFlushManager = function (logoutFlushManager) {
+        logoutFlushManager.numberOfQueues = logoutFlushManager.numberOfQueues+1;
     };
 
     clusive.djangoMessageQueue.getFlushInterval = function (defaultInterval, flushIntervalOverrideKey) {        
@@ -109,13 +109,13 @@
         promise.then(
             function(value) {                
                 that.events.queueFlushSuccess.fire(value);
-                that.logoutFlushRecorder.completedFlushes = that.logoutFlushRecorder.completedFlushes+1;
-                that.events.logoutFlushComplete.fire(that.logoutFlushRecorder.numberOfQueues, that.logoutFlushRecorder.completedFlushes);                
+                that.logoutFlushManager.completedFlushes = that.logoutFlushManager.completedFlushes+1;
+                that.events.logoutFlushComplete.fire(that.logoutFlushManager.numberOfQueues, that.logoutFlushManager.completedFlushes);                
             },
             function(error) {                
                 that.events.queueFlushFailure.fire(error);
-                that.logoutFlushRecorder.completedFlushes = that.logoutFlushRecorder.completedFlushes+1;
-                that.events.logoutFlushComplete.fire(that.logoutFlushRecorder.numberOfQueues, that.logoutFlushRecorder.completedFlushes);                
+                that.logoutFlushManager.completedFlushes = that.logoutFlushManager.completedFlushes+1;
+                that.events.logoutFlushComplete.fire(that.logoutFlushManager.numberOfQueues, that.logoutFlushManager.completedFlushes);                
             })    
     }
 

--- a/src/pages/templates/pages/debug.html
+++ b/src/pages/templates/pages/debug.html
@@ -147,7 +147,7 @@
                 var type = message.content.type;
                 var typeHumanReadable = eventTypes[type];
                 var displayedContent = getDisplayedMessageContent(message.content);
-                // var content = JSON.stringify(message.content);
+                
                 $("#queue-debug-table").find("tr:last").after(`<tr>
                     <td title="${eventId}">${eventId.substring(0,8)}...</td>
                     <td>${username}</td>
@@ -161,8 +161,8 @@
     function handleQueueLogEvent(localStorageKey) {
         var currentLogValue = JSON.parse(window.localStorage.getItem(localStorageKey));
         if(currentLogValue) {
-            var returnValue = JSON.stringify(currentLogValue.returnMessage);
-            var timestamp = JSON.stringify(currentLogValue.timestamp);
+            var returnValue = JSON.stringify(currentLogValue.returnMessage, null, 1);
+            var timestamp = JSON.stringify(currentLogValue.timestamp, null, 1);
             console.log("Log event: ", currentLogValue, localStorageKey);
             var selectorSuffix = localStorageKey.split(".").slice(0,3).join("-");
             console.log("selectorSuffix", selectorSuffix);

--- a/src/pages/templates/pages/debug.html
+++ b/src/pages/templates/pages/debug.html
@@ -59,6 +59,10 @@
         Last return message: <span id="queue-flush-return-message"></
         </td>
     </tr>
+    <tr>
+        <td>Items in queue: <span id="caliperEvents-length"></span></td>
+        <td>Items in queue: <span id="preferenceChanges-length"></span></td>
+    </tr>
 </table>
 <hr />
 <h2 id="debug-queue-heading">Message Queue Log</h2>
@@ -131,6 +135,8 @@
             console.log(localStorageKey + ' Storage Event / Current Queue: ', currentQueue);
             console.log('Last Queue:', lastValues[localStorageKey]); 
 
+            $('#' + localStorageKey.split('.')[2] + '-length').html(currentQueue.length);
+
             var newMessages = currentQueue.filter(function (message) {
                 var duplicate = false;            
                 lastValues[localStorageKey].forEach(function (m) {
@@ -155,6 +161,8 @@
                     <td>${displayedContent}</td></tr>`);
             })            
             lastValues[localStorageKey] = currentQueue;
+        } else {
+            $('#' + localStorageKey.split('.')[2] + '-length').html('null');
         }
     }
 


### PR DESCRIPTION
This fixes the bug with minimal changes to the existing code:
- adds a singleton component (`logoutFlushManager`) to track the number of flushes at logout and compare them against the number of `djangoMessageQueues`, which are now registered with the manager at creation
- do not perform the logout until the expected number of queues have been flushed (the bug was because there are now two separate message queues, and whichever one called back first caused the logout before the other could fush)

Longer-term, I'd like to move all "flush on logout" behaviour into the manager component, but that can be a separate JIRA.