### PR TITLE
CSL-809: handle zero-class scenarios for self-created Teacher/Parent accounts

### DIFF
--- a/src/roster/models.py
+++ b/src/roster/models.py
@@ -146,7 +146,7 @@ class ClusiveUser(models.Model):
         period = self.current_period or self.periods.first()
         if period:
             return period.site
-        # If the user can mage periods (Parent or Teacher) 
+        # If the user can manage periods (Parent or Teacher) 
         # and doesn't currently have a Site, we create
         # a personal one for them at this point
         if self.can_manage_periods:

--- a/src/roster/models.py
+++ b/src/roster/models.py
@@ -146,8 +146,16 @@ class ClusiveUser(models.Model):
         period = self.current_period or self.periods.first()
         if period:
             return period.site
-        return None
-
+        # If the user can mage periods (Parent or Teacher) 
+        # and doesn't currently have a Site, we create
+        # a personal one for them at this point
+        if self.can_manage_periods:
+            personal_site_name = "user-" + str(self.user.id) + "-personal-site"
+            personal_site = Site(name=personal_site_name)
+            personal_site.save()
+            return personal_site
+        else: 
+            return None
 
     @property 
     def is_permissioned(self):

--- a/src/roster/templates/roster/manage.html
+++ b/src/roster/templates/roster/manage.html
@@ -28,11 +28,12 @@
 <div class="content">
     <main id="content" tabindex="-1">
         <div class="row" style="align-items: baseline;">
+        {% if current_period %}
             <div class="col-md-auto pe-md-0_5">
                 <h1>
                     Manage:
                 </h1>
-            </div>
+            </div>            
             <div class="col ps-md-0 mb-0_5 mb-md-0">
                 <span id="period-name">{{ current_period.name }}</span>
                 <button id="period-edit-button" class="btn btn-primary btn-small ms-0_25">Edit</button>
@@ -45,8 +46,16 @@
                 </form>
             </div>
             {% include "shared/partial/period_selector.html" %}
+            {% else %}
+            <div class="col-md-auto pe-md-0_5">
+                <h1>
+                    No Classes
+                </h1>
+                <p><a href="{% url 'manage_create_period' %}">Add a Class</a> to get started using Clusive with your students or children.</p>
+            </div>            
+            {% endif %}            
         </div>
-
+        {% if current_period %}
         <div class="table-scroll">
             <table class="table table-divided table-roster">
                 <thead>
@@ -71,6 +80,7 @@
                 + Add Student
             </a>
         </p>
+        {% endif %}
     </main>
 
 {% endblock %}

--- a/src/roster/views.py
+++ b/src/roster/views.py
@@ -242,10 +242,10 @@ class ManageView(LoginRequiredMixin, EventMixin, TemplateView):
                 self.current_period = user.current_period
             elif self.periods:
                 self.current_period = self.periods[0]
-            else:
-                # No periods.  If this case actually happens, should have a better error message.
-                self.handle_no_permission()
-        if self.current_period != user.current_period:
+            # else:
+            #     # No periods.  If this case actually happens, should have a better error message.
+            #     self.handle_no_permission()
+        if self.current_period != user.current_period and self.current_period != None:
             user.current_period = self.current_period
             user.save()
         return super().get(request, *args, **kwargs)
@@ -254,9 +254,10 @@ class ManageView(LoginRequiredMixin, EventMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         context['periods'] = self.periods
         context['current_period'] = self.current_period
-        context['students'] = self.make_student_info_list()
-        context['period_name_form'] = PeriodForm(instance=self.current_period)
-        logger.debug('Students: %s', context['students'])
+        if self.current_period != None:
+            context['students'] = self.make_student_info_list()
+            context['period_name_form'] = PeriodForm(instance=self.current_period)
+            logger.debug('Students: %s', context['students'])
         return context
 
     def make_student_info_list(self):


### PR DESCRIPTION
Allows self-created Teacher/Parent accounts to create classes, create students for them, and assign readings.

On the back end, creates a personal `Site` for a parent/teacher account when they first try to add a new class. This is necessary with the current model.