### PR TITLE
CSL-917: generate robots.txt file blocking /account

### DIFF
--- a/src/clusive_project/urls.py
+++ b/src/clusive_project/urls.py
@@ -17,10 +17,13 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from django.conf.urls import url
+from django.http import HttpResponse
 
 urlpatterns = [        
     path('admin/', admin.site.urls),
     path('', include('pages.urls')),
+    url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /account", content_type="text/plain"), name="robots_file"),    
     path('account/', include('roster.urls')),
     path('assessment/', include('assessment.urls')),
     path('author/', include('authoring.urls')),


### PR DESCRIPTION
This should block crawlers that respect `robots.txt` from following any `/account` URLs, including the guest login.

Found at https://stackoverflow.com/questions/18424260/django-serving-robots-txt-efficiently, which suggests serving `robots.txt` as a static file, but I'm uncertain of our static file server configuration in production, and this should be fine for now given our traffic levels.