### PR TITLE
CSL-945: add build scripts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ To try it out quickly using Docker skip ahead to that section.
 
 ## Local Installation
 
-Note: all steps between **Create/Activitate Virtual Environment** and **Create a Superuser** can be run using `local_install.sh` (on Unix-based systems) or `local_install.ps1` (on Windows) to more easily set up or refresh a local environment.
+Note: all steps between **Create/Activitate Virtual Environment** and **Create a Superuser** can be run using `local_install.sh` (on Unix-based systems) or `local_install.ps1` (on Windows) to more easily set up or refresh a local environment. Be sure to set up your virtual environment first.
 
 ### Prerequisites
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,8 @@ To try it out quickly using Docker skip ahead to that section.
 
 ## Local Installation
 
+Note: all steps between **Create/Activitate Virtual Environment** and **Create a Superuser** can be run using `local_install.sh` (on Unix-based systems) or `local_install.ps1` (on Windows) to more easily set up or refresh a local environment.
+
 ### Prerequisites
 
 * [Python 3](https://www.python.org/downloads/)
@@ -79,12 +81,6 @@ To initialize the schema and initial data, run in the Clusive\target directory:
 * `python manage.py migrate`
 * `python manage.py loaddata preferencesets tiptypes subjects` 
 
-
-### Create a Superuser
-
-Run in the Clusive\target directory:
-* `python manage.py createsuperuser`
-
 ### Import public content
 There are a number of learning materials ready for import in the Clusive\content directory.
 
@@ -100,6 +96,11 @@ or multiple files which are considered to be a set of leveled versions
 of the same content. A glossary JSON file and directory of images that
 it refers to can also be included on the command line.
 The content directory contains many examples of these.  
+
+### Create a Superuser
+
+Run in the Clusive\target directory:
+* `python manage.py createsuperuser`
 
 ### Verify the Application
 

--- a/local_install.ps1
+++ b/local_install.ps1
@@ -1,0 +1,13 @@
+# Run from the root 'clusive' directory
+
+./env/Scripts/activate
+npm install
+pip install -r requirements.txt
+python -m nltk.downloader wordnet
+grunt build
+cd target
+python manage.py migrate
+python manage.py loaddata preferencesets tiptypes subjects
+python manage.py importdir ../content
+echo "Setup complete! Run python manage.py createsuperuser to create the super user and you're all done"
+cd ..

--- a/local_install.ps1
+++ b/local_install.ps1
@@ -1,4 +1,4 @@
-# Run from the root 'clusive' directory
+# Run from the root 'clusive' directory after setting up your virtual environment
 
 ./env/Scripts/activate
 npm install

--- a/local_install.sh
+++ b/local_install.sh
@@ -1,6 +1,6 @@
-# Run from the root 'clusive' directory
+# Run from the root 'clusive' directory after setting up your virtual environment
 
-source ./env/scripts/activate
+source ./env/bin/activate
 npm install
 pip install -r requirements.txt
 python -m nltk.downloader wordnet

--- a/local_install.sh
+++ b/local_install.sh
@@ -1,0 +1,13 @@
+# Run from the root 'clusive' directory
+
+source ./env/scripts/activate
+npm install
+pip install -r requirements.txt
+python -m nltk.downloader wordnet
+grunt build
+cd target
+python manage.py migrate
+python manage.py loaddata preferencesets tiptypes subjects
+python manage.py importdir ../content
+echo "Setup complete! Run python manage.py createsuperuser to create the super user and you're all done"
+cd ..


### PR DESCRIPTION
Adds build scripts to automate away (most) of the steps for setting up or refreshing a local dev environment.

I've tested these myself (using WSL to test the `.sh` on my Windows machine), but if someone using a Mac can confirm the `.sh` script works for them, I think we can merge this and make people's lives a bit easier.