### PR TITLE
CSL-944: autosave

### DIFF
--- a/src/assessment/models.py
+++ b/src/assessment/models.py
@@ -41,8 +41,8 @@ class AffectiveCheck:
     ]    
 
 class ComprehensionCheck:
-    scale_response_key = "scale_response"
-    free_response_key = "free_response"
+    scale_response_key = "scaleResponse"
+    free_response_key = "freeResponse"
 
     class ComprehensionScale:
         NOTHING = 0

--- a/src/assessment/urls.py
+++ b/src/assessment/urls.py
@@ -2,9 +2,8 @@ from django.urls import path
 
 from . import views
 
-urlpatterns = [
-    path('affect_check', views.AffectCheckView.as_view(), name='affect_check_set'),
-    path('affect_check/<int:book_id>', views.AffectCheckView.as_view(), name='affect_check_get'),
+urlpatterns = [    
+    path('affect_check/<int:book_id>', views.AffectCheckView.as_view(), name='affect_check_view'),
     path('comprehension_check', views.ComprehensionCheckView.as_view(), name='comprehension_check_set'),    
     path('comprehension_check/<int:book_id>', views.ComprehensionCheckView.as_view(), name='comprehension_check_get')    
 ]

--- a/src/assessment/urls.py
+++ b/src/assessment/urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [    
-    path('affect_check/<int:book_id>', views.AffectCheckView.as_view(), name='affect_check_view'),
-    path('comprehension_check', views.ComprehensionCheckView.as_view(), name='comprehension_check_set'),    
-    path('comprehension_check/<int:book_id>', views.ComprehensionCheckView.as_view(), name='comprehension_check_get')    
+    path('affect_check/<int:book_id>', views.AffectCheckView.as_view(), name='affect_check_view'),    
+    path('comprehension_check/<int:book_id>', views.ComprehensionCheckView.as_view(), name='comprehension_check_view')    
 ]

--- a/src/assessment/views.py
+++ b/src/assessment/views.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 
 class AffectCheckView(LoginRequiredMixin, View):
     @staticmethod
-    def create_from_request(request, affect_check_data):
+    def create_from_request(request, affect_check_data, book_id):
         clusive_user = request.clusive_user
         logger.debug("create with data: %s", affect_check_data)
         logger.debug("create with data_bookId: %s", affect_check_data.get("bookId"))
-        book = Book.objects.get(id=affect_check_data.get("bookId"))            
+        book = Book.objects.get(id=book_id)            
 
         (acr, created) = AffectiveCheckResponse.objects.get_or_create(user=clusive_user, book=book)
         acr.annoyed_option_response = affect_check_data.get('affect-option-annoyed')
@@ -43,7 +43,7 @@ class AffectCheckView(LoginRequiredMixin, View):
                                   affect_check_response_id=acr.id,                                  
                                   answer=acr.toAnswerString())
         
-    def post(self, request):
+    def post(self, request, book_id):
         try:
             affect_check_data = json.loads(request.body)
             logger.info('Received a valid affect check response: %s' % affect_check_data)
@@ -51,7 +51,7 @@ class AffectCheckView(LoginRequiredMixin, View):
             logger.warning('Received malformed affect check data: %s' % request.body)
             return JsonResponse(status=501, data={'message': 'Invalid JSON in request body'}) 
 
-        AffectCheckView.create_from_request(request, affect_check_data)                
+        AffectCheckView.create_from_request(request, affect_check_data, book_id)                
 
         return JsonResponse({"success": "1"})
 
@@ -77,9 +77,9 @@ class AffectCheckView(LoginRequiredMixin, View):
 
 class ComprehensionCheckView(LoginRequiredMixin, View):
     @staticmethod
-    def create_from_request(request, comprehension_check_data):    
+    def create_from_request(request, comprehension_check_data, book_id):    
         clusive_user = request.clusive_user
-        book = Book.objects.get(id=comprehension_check_data.get("bookId"))
+        book = Book.objects.get(id=book_id)
 
         (ccr, created) = ComprehensionCheckResponse.objects.get_or_create(user=clusive_user, book=book)
         ccr.comprehension_scale_response = comprehension_check_data.get('scaleResponse')
@@ -94,7 +94,7 @@ class ComprehensionCheckView(LoginRequiredMixin, View):
                                 key=ComprehensionCheck.scale_response_key,
                                 question=comprehension_check_data.get('scaleQuestion'),
                                 answer=ccr.comprehension_scale_response)
-                                
+
         comprehension_check_completed.send(sender=ComprehensionCheckView,
                                 request=request, event_id=page_event_id,
                                 comprehension_check_response_id=ccr.id,
@@ -102,7 +102,7 @@ class ComprehensionCheckView(LoginRequiredMixin, View):
                                 question=comprehension_check_data.get('freeQuestion'),
                                 answer=ccr.comprehension_free_response)            
 
-    def post(self, request):            
+    def post(self, request, book_id):            
         try:
             comprehension_check_data = json.loads(request.body)            
             logger.info('Received a valid comprehension check response: %s' % comprehension_check_data)
@@ -110,7 +110,7 @@ class ComprehensionCheckView(LoginRequiredMixin, View):
             logger.warning('Received malformed comprehension check data: %s' % request.body)
             return JsonResponse(status=501, data={'message': 'Invalid JSON in request body'})
 
-        ComprehensionCheckView.create_from_request(request, comprehension_check_data)
+        ComprehensionCheckView.create_from_request(request, comprehension_check_data, book_id)
                 
         return JsonResponse({"success": "1"})
 

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -50,7 +50,9 @@ clusiveAssessment.setComprehensionCheck = function(data) {
     var freeResponse = data.freeResponse;
     $('textarea[name="comprehension-free"]').val(freeResponse);
     $('input[name="comprehension-scale"]').val([scaleResponse]);
-    $('input[name="comprehension-scale"]').change();
+    if(freeResponse.length > 0) {
+        $('#comprehensionFreeResponseArea').show();
+    }    
 }
 
 clusiveAssessment.saveAffectCheck = function () {    
@@ -101,11 +103,12 @@ clusiveAssessment.setupAssessments = function() {
 
     clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
 
+    // TODO: this should be an onchange on the elements
     window.setInterval(function() {
         console.log("adding current state of assessments to autosave queue")
         clusiveAssessment.saveAffectCheck();
         clusiveAssessment.saveComprehensionCheck();        
-    }, 15000)
+    }, 1000)
 
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -103,11 +103,18 @@ clusiveAssessment.setupAssessments = function() {
 
     clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
     
-    window.setInterval(function() {
-        console.log("adding current state of assessments to autosave queue")
+    // Set up autosave calls for change events on relevant inputs
+    
+    $('input[name^="affect-option"]').change(function () {
         clusiveAssessment.saveAffectCheck();
-        clusiveAssessment.saveComprehensionCheck();        
-    }, 15000)
+    });
+
+    $('input[name="comprehension-scale"]').change(function() {
+        clusiveAssessment.saveComprehensionCheck();
+    });
+    $('textarea[name="comprehension-free"]').change(function() {
+        clusiveAssessment.saveComprehensionCheck();
+    });
 
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -25,8 +25,7 @@ clusiveAssessment.showCompCheck = function() {
     }
 };
 
-clusiveAssessment.setAffectCheck = function(data) {
-    console.log("calling setAffectCheck", data)
+clusiveAssessment.setAffectCheck = function(data) {    
     Object.keys(data).forEach(function (key) {
         if(key.includes("affect-option")) {
             var affectOptionName = key                
@@ -40,14 +39,12 @@ clusiveAssessment.setAffectCheck = function(data) {
                 reactDimAnimate(wedge, 100);
             } else {
                 reactDimAnimate(wedge, 0);
-            }
-            console.log("affectInput", affectInput, shouldCheck);
+            }            
             }
     })
 }
 
-clusiveAssessment.setComprehensionCheck = function(data) {
-    console.log("calling setComprehensionCheck", data);
+clusiveAssessment.setComprehensionCheck = function(data) {    
     clusiveAssessment.compCheckDone = true;
     var scaleResponse = data.scaleResponse;
     var freeResponse = data.freeResponse;
@@ -71,16 +68,14 @@ clusiveAssessment.setUpCompCheck = function() {
         },
         retrieve: 
             function(url, callback) {
-                var hasLocal = false;
-                console.log("autosave queue", autosave.queue.getMessages());
+                var hasLocal = false;                
                 var autosaveMessages = [].concat(autosave.queue.getMessages()).filter(function (item) {                    
                         if(item.content.type === "AS" && item.content.url === url) {
                             return true;
                         }                    
                 });
                 
-                if(autosaveMessages.length > 0) {                    
-                    console.log("autosaveMessages", autosaveMessages);
+                if(autosaveMessages.length > 0) {                                        
                     var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
                     console.log("local data for url: " + url + " found", latestLocalData);
                     callback(latestLocalData);

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -53,7 +53,8 @@ clusiveAssessment.setComprehensionCheck = function(data) {
     $('input[name="comprehension-scale"]').change();
 }
 
-clusiveAssessment.saveAffectCheck = function () {
+clusiveAssessment.saveAffectCheck = function () {    
+    var bookId = clusiveContext.reader.info.publication.id;
     // Create basic affect response structure
     var affectResponse = {
         bookVersionId: clusiveContext.reader.info.publication.version_id,
@@ -67,10 +68,12 @@ clusiveAssessment.saveAffectCheck = function () {
     checkedAffectInputs.each(function (i, elem) {
         affectResponse[elem.name] = elem.checked
     });        
+
     clusiveAutosave.save("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));        
 }
 
-clusiveAssessment.saveComprehensionCheck = function () {
+clusiveAssessment.saveComprehensionCheck = function () {        
+    var bookId = clusiveContext.reader.info.publication.id;
     var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
     var freeResponse = $('textarea[name="comprehension-free"]').val();
     var comprehensionResponse = {

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -25,6 +25,39 @@ clusiveAssessment.showCompCheck = function() {
     }
 };
 
+clusiveAssessment.setAffectCheck = function(data) {
+    console.log("calling set_affect_check", data)
+    Object.keys(data).forEach(function (key) {
+        if(key.includes("affect-option")) {
+            var affectOptionName = key                
+            var shouldCheck = data[affectOptionName];
+            var affectInput = $('input[name="' + affectOptionName + '"]');
+            affectInput.prop("checked", shouldCheck);
+            var idx = affectInput.attr("data-react-index");
+            var wedge = document.querySelector('.react-wedge-' + idx);
+    
+            if(shouldCheck) {
+                reactDimAnimate(wedge, 100);
+            } else {
+                reactDimAnimate(wedge, 0);
+            }
+            console.log("affectInput", affectInput, shouldCheck);
+            }
+    })
+}
+
+clusiveAssessment.setComprehensionCheck = function(data) {
+    var set_comprehension_check = function(data) {
+        console.log("calling set_comprehension_check", data);
+        clusiveAssessment.compCheckDone = true;
+        var scaleResponse = data.scaleResponse;
+        var freeResponse = data.freeResponse;
+        $('textarea[name="comprehension-free"]').val(freeResponse);
+        $('input[name="comprehension-scale"]').val([scaleResponse]);
+        $('input[name="comprehension-scale"]').change();
+    };        
+}
+
 clusiveAssessment.setUpCompCheck = function() {
     'use strict';
 
@@ -77,40 +110,43 @@ clusiveAssessment.setUpCompCheck = function() {
 
     // Retrieve existing affect check values and set them
 
-    var set_affect_check = function(data) {
-        console.log("calling set_affect_check", data)
-        Object.keys(data).forEach(function (key) {
-            if(key.includes("affect-option")) {
-                var affectOptionName = key                
-                var shouldCheck = data[affectOptionName];
-                var affectInput = $('input[name="' + affectOptionName + '"]');
-                affectInput.prop("checked", shouldCheck);
-                var idx = affectInput.attr("data-react-index");
-                var wedge = document.querySelector('.react-wedge-' + idx);
+    clusiveAssessment.setAffectCheck;
+    clusiveAssessment.setCompCheck;
+
+    // var set_affect_check = function(data) {
+    //     console.log("calling set_affect_check", data)
+    //     Object.keys(data).forEach(function (key) {
+    //         if(key.includes("affect-option")) {
+    //             var affectOptionName = key                
+    //             var shouldCheck = data[affectOptionName];
+    //             var affectInput = $('input[name="' + affectOptionName + '"]');
+    //             affectInput.prop("checked", shouldCheck);
+    //             var idx = affectInput.attr("data-react-index");
+    //             var wedge = document.querySelector('.react-wedge-' + idx);
         
-                if(shouldCheck) {
-                    reactDimAnimate(wedge, 100);
-                } else {
-                    reactDimAnimate(wedge, 0);
-                }
-                console.log("affectInput", affectInput, shouldCheck);
-                }
-        })
-    };
+    //             if(shouldCheck) {
+    //                 reactDimAnimate(wedge, 100);
+    //             } else {
+    //                 reactDimAnimate(wedge, 0);
+    //             }
+    //             console.log("affectInput", affectInput, shouldCheck);
+    //             }
+    //     })
+    // };
 
-    autosave.retrieve('/assessment/affect_check/' + bookId, set_affect_check);
+    autosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
 
-    var set_comprehension_check = function(data) {
-        console.log("calling set_comprehension_check", data);
-        clusiveAssessment.compCheckDone = true;
-        var scaleResponse = data.scaleResponse;
-        var freeResponse = data.freeResponse;
-        $('textarea[name="comprehension-free"]').val(freeResponse);
-        $('input[name="comprehension-scale"]').val([scaleResponse]);
-        $('input[name="comprehension-scale"]').change();
-    };
+    // var set_comprehension_check = function(data) {
+    //     console.log("calling set_comprehension_check", data);
+    //     clusiveAssessment.compCheckDone = true;
+    //     var scaleResponse = data.scaleResponse;
+    //     var freeResponse = data.freeResponse;
+    //     $('textarea[name="comprehension-free"]').val(freeResponse);
+    //     $('input[name="comprehension-scale"]').val([scaleResponse]);
+    //     $('input[name="comprehension-scale"]').change();
+    // };
 
-    autosave.retrieve('/assessment/comprehension_check/' + bookId, set_comprehension_check);
+    autosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
 
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -110,41 +110,7 @@ clusiveAssessment.setUpCompCheck = function() {
 
     // Retrieve existing affect check values and set them
 
-    clusiveAssessment.setAffectCheck;
-    clusiveAssessment.setCompCheck;
-
-    // var set_affect_check = function(data) {
-    //     console.log("calling set_affect_check", data)
-    //     Object.keys(data).forEach(function (key) {
-    //         if(key.includes("affect-option")) {
-    //             var affectOptionName = key                
-    //             var shouldCheck = data[affectOptionName];
-    //             var affectInput = $('input[name="' + affectOptionName + '"]');
-    //             affectInput.prop("checked", shouldCheck);
-    //             var idx = affectInput.attr("data-react-index");
-    //             var wedge = document.querySelector('.react-wedge-' + idx);
-        
-    //             if(shouldCheck) {
-    //                 reactDimAnimate(wedge, 100);
-    //             } else {
-    //                 reactDimAnimate(wedge, 0);
-    //             }
-    //             console.log("affectInput", affectInput, shouldCheck);
-    //             }
-    //     })
-    // };
-
     autosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
-
-    // var set_comprehension_check = function(data) {
-    //     console.log("calling set_comprehension_check", data);
-    //     clusiveAssessment.compCheckDone = true;
-    //     var scaleResponse = data.scaleResponse;
-    //     var freeResponse = data.freeResponse;
-    //     $('textarea[name="comprehension-free"]').val(freeResponse);
-    //     $('input[name="comprehension-scale"]').val([scaleResponse]);
-    //     $('input[name="comprehension-scale"]').change();
-    // };
 
     autosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
 

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -28,12 +28,23 @@ clusiveAssessment.showCompCheck = function() {
 clusiveAssessment.setUpCompCheck = function() {
     'use strict';
 
-    var autosaveQueue = clusive.djangoMessageQueue({
-        config: {                        
-            localStorageKey: "clusive.messageQueue.autosave",
-            lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
-        }
-    });
+    var autosave = {
+        queue: clusive.djangoMessageQueue({
+                config: {                        
+                    localStorageKey: "clusive.messageQueue.autosave",
+                    lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
+                }
+            }),
+        set: function(url, data) {
+            autosave.queue.add({"type": "AS", "url": url, "data": data});
+        },
+        retrieve: {
+            function(url) {
+
+            }
+        }                
+    };
+
 
     var bookId = clusiveContext.reader.info.publication.id;
 
@@ -115,9 +126,8 @@ clusiveAssessment.setUpCompCheck = function() {
             checkedAffectInputs.each(function (i, elem) {
                 affectResponse[elem.name] = elem.checked
             });
-
-
-            autosaveQueue.add({"type": "AS", "url": "/assessment/affect_check", "data": JSON.stringify(affectResponse)});
+            
+            autosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));
 
             // $.ajax('/assessment/affect_check', {
             //     method: 'POST',
@@ -146,20 +156,22 @@ clusiveAssessment.setUpCompCheck = function() {
                 eventId: PAGE_EVENT_ID
             };
 
-            $.ajax('/assessment/comprehension_check', {
-                method: 'POST',
-                headers: {
-                    'X-CSRFToken': DJANGO_CSRF_TOKEN
-                },
-                data: JSON.stringify(comprehensionResponse)
-            })
-                .done(function(data) {
-                    console.debug('Comp check save complete', data);
-                    clusiveAssessment.compCheckDone = true;
-                })
-                .fail(function(err) {
-                    console.error('Comp check save failed!', err);
-                });
+            // $.ajax('/assessment/comprehension_check', {
+            //     method: 'POST',
+            //     headers: {
+            //         'X-CSRFToken': DJANGO_CSRF_TOKEN
+            //     },
+            //     data: JSON.stringify(comprehensionResponse)
+            // })
+            //     .done(function(data) {
+            //         console.debug('Comp check save complete', data);
+            //         clusiveAssessment.compCheckDone = true;
+            //     })
+            //     .fail(function(err) {
+            //         console.error('Comp check save failed!', err);
+            //     });
+
+            autosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
 
             $(this).closest('.popover').CFW_Popover('hide');
         });

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -67,7 +67,7 @@ clusiveAssessment.saveAffectCheck = function () {
     checkedAffectInputs.each(function (i, elem) {
         affectResponse[elem.name] = elem.checked
     });        
-    clusiveAutosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));        
+    clusiveAutosave.save("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));        
 }
 
 clusiveAssessment.saveComprehensionCheck = function () {
@@ -82,7 +82,7 @@ clusiveAssessment.saveComprehensionCheck = function () {
         bookId: clusiveContext.reader.info.publication.id,
         eventId: PAGE_EVENT_ID
     };
-    clusiveAutosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
+    clusiveAutosave.save("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
 }
 
 clusiveAssessment.setUpCompCheck = function() {

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -53,49 +53,40 @@ clusiveAssessment.setComprehensionCheck = function(data) {
     $('input[name="comprehension-scale"]').change();
 }
 
+clusiveAssessment.saveAffectCheck = function () {
+    // Create basic affect response structure
+    var affectResponse = {
+        bookVersionId: clusiveContext.reader.info.publication.version_id,
+        bookId: clusiveContext.reader.info.publication.id,
+        eventId: PAGE_EVENT_ID
+    };
+
+    // Get all affect inputs
+    var checkedAffectInputs = $('input[name^="affect-option"]');
+    // Add to data object
+    checkedAffectInputs.each(function (i, elem) {
+        affectResponse[elem.name] = elem.checked
+    });        
+    clusiveAutosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));        
+}
+
+clusiveAssessment.saveComprehensionCheck = function () {
+    var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
+    var freeResponse = $('textarea[name="comprehension-free"]').val();
+    var comprehensionResponse = {
+        scaleQuestion: $('#compScaleQuestion').text(),
+        scaleResponse: scaleResponse,
+        freeQuestion: $('#compFreeQuestion').children(':visible').text(),
+        freeResponse: freeResponse,
+        bookVersionId: clusiveContext.reader.info.publication.version_id,
+        bookId: clusiveContext.reader.info.publication.id,
+        eventId: PAGE_EVENT_ID
+    };
+    clusiveAutosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
+}
+
 clusiveAssessment.setUpCompCheck = function() {
     'use strict';
-
-    // var autosave = {
-    //     queue: clusive.djangoMessageQueue({
-    //             config: {                        
-    //                 localStorageKey: "clusive.messageQueue.autosave",
-    //                 lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
-    //             }
-    //         }),
-    //     set: function(url, data) {
-    //         autosave.queue.add({"type": "AS", "url": url, "data": data});
-    //     },
-    //     retrieve: 
-    //         function(url, callback) {
-    //             var hasLocal = false;                
-    //             var autosaveMessages = [].concat(autosave.queue.getMessages()).filter(function (item) {                    
-    //                     if(item.content.type === "AS" && item.content.url === url) {
-    //                         return true;
-    //                     }                    
-    //             });
-                
-    //             if(autosaveMessages.length > 0) {                                        
-    //                 var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
-    //                 console.log("local data for url: " + url + " found", latestLocalData);
-    //                 callback(latestLocalData);
-    //             } else {                   
-    //                 console.log("No local data for url: " + url + ", trying to get from server");
-    //                 $.get(url, function(data) {
-    //                     console.log("Found data on server for url: " + url);
-    //                     callback(data);                    
-    //                 }).fail(function(error) {
-    //                     if (error.status === 404) {
-    //                         console.debug('No matching data on server for url: ' + url);
-    //                     } else {
-    //                         console.warn('failed to get data: ', error.status);
-    //                     }
-    //                 });
-    //             }                 
-    //         }                
-    // };
-
-
     var bookId = clusiveContext.reader.info.publication.id;
 
     // Block auto-show for at least 10 seconds after page load, to prevent it erroneously getting shown.
@@ -129,35 +120,9 @@ clusiveAssessment.setUpCompCheck = function() {
         function(e) {
             e.preventDefault();
 
-            // Create basic affect response structure
-            var affectResponse = {
-                bookVersionId: clusiveContext.reader.info.publication.version_id,
-                bookId: clusiveContext.reader.info.publication.id,
-                eventId: PAGE_EVENT_ID
-            };
+            clusiveAssessment.saveAffectCheck();
 
-            // Get all affect inputs
-            var checkedAffectInputs = $('input[name^="affect-option"]');
-            // Add to data object
-            checkedAffectInputs.each(function (i, elem) {
-                affectResponse[elem.name] = elem.checked
-            });
-            
-            clusiveAutosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));
-
-            var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
-            var freeResponse = $('textarea[name="comprehension-free"]').val();
-            var comprehensionResponse = {
-                scaleQuestion: $('#compScaleQuestion').text(),
-                scaleResponse: scaleResponse,
-                freeQuestion: $('#compFreeQuestion').children(':visible').text(),
-                freeResponse: freeResponse,
-                bookVersionId: clusiveContext.reader.info.publication.version_id,
-                bookId: clusiveContext.reader.info.publication.id,
-                eventId: PAGE_EVENT_ID
-            };
-
-            clusiveAutosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
+            clusiveAssessment.saveComprehensionCheck();                  
 
             $(this).closest('.popover').CFW_Popover('hide');
         });

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -26,7 +26,7 @@ clusiveAssessment.showCompCheck = function() {
 };
 
 clusiveAssessment.setAffectCheck = function(data) {
-    console.log("calling set_affect_check", data)
+    console.log("calling setAffectCheck", data)
     Object.keys(data).forEach(function (key) {
         if(key.includes("affect-option")) {
             var affectOptionName = key                
@@ -47,15 +47,13 @@ clusiveAssessment.setAffectCheck = function(data) {
 }
 
 clusiveAssessment.setComprehensionCheck = function(data) {
-    var set_comprehension_check = function(data) {
-        console.log("calling set_comprehension_check", data);
-        clusiveAssessment.compCheckDone = true;
-        var scaleResponse = data.scaleResponse;
-        var freeResponse = data.freeResponse;
-        $('textarea[name="comprehension-free"]').val(freeResponse);
-        $('input[name="comprehension-scale"]').val([scaleResponse]);
-        $('input[name="comprehension-scale"]').change();
-    };        
+    console.log("calling setComprehensionCheck", data);
+    clusiveAssessment.compCheckDone = true;
+    var scaleResponse = data.scaleResponse;
+    var freeResponse = data.freeResponse;
+    $('textarea[name="comprehension-free"]').val(freeResponse);
+    $('input[name="comprehension-scale"]').val([scaleResponse]);
+    $('input[name="comprehension-scale"]').change();
 }
 
 clusiveAssessment.setUpCompCheck = function() {
@@ -82,8 +80,9 @@ clusiveAssessment.setUpCompCheck = function() {
                 });
                 
                 if(autosaveMessages.length > 0) {                    
+                    console.log("autosaveMessages", autosaveMessages);
                     var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
-                    console.log("local data for url: " + url + " found");
+                    console.log("local data for url: " + url + " found", latestLocalData);
                     callback(latestLocalData);
                 } else {                   
                     console.log("No local data for url: " + url + ", trying to get from server");

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -53,45 +53,6 @@ clusiveAssessment.setComprehensionCheck = function(data) {
     $('input[name="comprehension-scale"]').change();
 }
 
-var autosave = {
-    queue: clusive.djangoMessageQueue({
-            config: {                        
-                localStorageKey: "clusive.messageQueue.autosave",
-                lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
-            }
-        }),
-    set: function(url, data) {
-        autosave.queue.add({"type": "AS", "url": url, "data": data});
-    },
-    retrieve: 
-        function(url, callback) {
-            var hasLocal = false;                
-            var autosaveMessages = [].concat(autosave.queue.getMessages()).filter(function (item) {                    
-                    if(item.content.type === "AS" && item.content.url === url) {
-                        return true;
-                    }                    
-            });
-            
-            if(autosaveMessages.length > 0) {                                        
-                var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
-                console.log("local data for url: " + url + " found", latestLocalData);
-                callback(latestLocalData);
-            } else {                   
-                console.log("No local data for url: " + url + ", trying to get from server");
-                $.get(url, function(data) {
-                    console.log("Found data on server for url: " + url);
-                    callback(data);                    
-                }).fail(function(error) {
-                    if (error.status === 404) {
-                        console.debug('No matching data on server for url: ' + url);
-                    } else {
-                        console.warn('failed to get data: ', error.status);
-                    }
-                });
-            }                 
-        }                
-};
-
 clusiveAssessment.setUpCompCheck = function() {
     'use strict';
 
@@ -143,9 +104,9 @@ clusiveAssessment.setUpCompCheck = function() {
 
     // Retrieve existing affect check values and set them
 
-    autosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
+    clusiveAutosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
 
-    autosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
+    clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
 
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(
@@ -182,7 +143,7 @@ clusiveAssessment.setUpCompCheck = function() {
                 affectResponse[elem.name] = elem.checked
             });
             
-            autosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));
+            clusiveAutosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));
 
             var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
             var freeResponse = $('textarea[name="comprehension-free"]').val();
@@ -196,7 +157,7 @@ clusiveAssessment.setUpCompCheck = function() {
                 eventId: PAGE_EVENT_ID
             };
 
-            autosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
+            clusiveAutosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
 
             $(this).closest('.popover').CFW_Popover('hide');
         });

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -112,22 +112,6 @@ clusiveAssessment.setUpCompCheck = function() {
 
     autosave.retrieve('/assessment/comprehension_check/' + bookId, set_comprehension_check);
 
-    // // Retrieve existing comprehension check values and set them
-    // $.get('/assessment/comprehension_check/' + bookId, function(data) {
-    //     clusiveAssessment.compCheckDone = true;
-    //     var scaleResponse = data.scale_response;
-    //     var freeResponse = data.free_response;
-    //     $('textarea[name="comprehension-free"]').val(freeResponse);
-    //     $('input[name="comprehension-scale"]').val([scaleResponse]);
-    //     $('input[name="comprehension-scale"]').change();
-    // }).fail(function(error) {
-    //     if (error.status === 404) {
-    //         console.debug('No pre-existing comp check response');
-    //     } else {
-    //         console.warn('failed to get comprehension check, status code: ', error.status);
-    //     }
-    // });
-
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(
         function() {
@@ -165,21 +149,6 @@ clusiveAssessment.setUpCompCheck = function() {
             
             autosave.set("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));
 
-            // $.ajax('/assessment/affect_check', {
-            //     method: 'POST',
-            //     headers: {
-            //         'X-CSRFToken': DJANGO_CSRF_TOKEN
-            //     },
-            //     data: JSON.stringify(affectResponse)
-            // })
-            //     .done(function(data) {
-            //         console.debug('Affect check save complete', data);
-            //         clusiveAssessment.affectCheckDone = true;
-            //     })
-            //     .fail(function(err) {
-            //         console.error('Affect check save failed!', err);
-            //     });
-
             var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
             var freeResponse = $('textarea[name="comprehension-free"]').val();
             var comprehensionResponse = {
@@ -191,21 +160,6 @@ clusiveAssessment.setUpCompCheck = function() {
                 bookId: clusiveContext.reader.info.publication.id,
                 eventId: PAGE_EVENT_ID
             };
-
-            // $.ajax('/assessment/comprehension_check', {
-            //     method: 'POST',
-            //     headers: {
-            //         'X-CSRFToken': DJANGO_CSRF_TOKEN
-            //     },
-            //     data: JSON.stringify(comprehensionResponse)
-            // })
-            //     .done(function(data) {
-            //         console.debug('Comp check save complete', data);
-            //         clusiveAssessment.compCheckDone = true;
-            //     })
-            //     .fail(function(err) {
-            //         console.error('Comp check save failed!', err);
-            //     });
 
             autosave.set("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
 

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -85,7 +85,7 @@ clusiveAssessment.saveComprehensionCheck = function () {
     clusiveAutosave.save("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
 }
 
-clusiveAssessment.setUpCompCheck = function() {
+clusiveAssessment.setupAssessments = function() {
     'use strict';
     var bookId = clusiveContext.reader.info.publication.id;
 
@@ -134,7 +134,7 @@ $(function() {
     $(document).ready(function() {
         // Don't set up a comp check unless on a book page
         if (fluid.get(clusiveContext, 'reader.info.publication.id')) {
-            clusiveAssessment.setUpCompCheck();
+            clusiveAssessment.setupAssessments();
         }
     });
 });

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -69,7 +69,7 @@ clusiveAssessment.saveAffectCheck = function () {
         affectResponse[elem.name] = elem.checked
     });        
 
-    clusiveAutosave.save("/assessment/affect_check/" + bookId, JSON.stringify(affectResponse));        
+    clusiveAutosave.save("/assessment/affect_check/" + bookId, affectResponse);        
 }
 
 clusiveAssessment.saveComprehensionCheck = function () {        
@@ -85,7 +85,7 @@ clusiveAssessment.saveComprehensionCheck = function () {
         bookId: clusiveContext.reader.info.publication.id,
         eventId: PAGE_EVENT_ID
     };
-    clusiveAutosave.save("/assessment/comprehension_check/" + bookId, JSON.stringify(comprehensionResponse));
+    clusiveAutosave.save("/assessment/comprehension_check/" + bookId, comprehensionResponse);
 }
 
 clusiveAssessment.setupAssessments = function() {
@@ -97,7 +97,6 @@ clusiveAssessment.setupAssessments = function() {
     window.setTimeout(function() { clusiveAssessment.tooEarly = false; }, 10000);
 
     // Retrieve existing affect check values and set them
-
     clusiveAutosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
 
     clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -38,23 +38,12 @@ clusiveAssessment.setUpCompCheck = function() {
         set: function(url, data) {
             autosave.queue.add({"type": "AS", "url": url, "data": data});
         },
-        retrieve: {
+        retrieve: 
             function(url, callback) {
-                $.get(url, callback(data) {
-                    Object.keys(data).forEach(function (affectOptionName) {
-                        var shouldCheck = data[affectOptionName];
-                        var affectInput = $('input[name="' + affectOptionName + '"]');
-                        affectInput.prop("checked", shouldCheck);
-                        var idx = affectInput.attr("data-react-index");
-                        var wedge = document.querySelector('.react-wedge-' + idx);
-            
-                        if(shouldCheck) {
-                            reactDimAnimate(wedge, 100);
-                        } else {
-                            reactDimAnimate(wedge, 0);
-                        }
-                        console.log("affectInput", affectInput, shouldCheck);
-                    })
+                console.log("No local data for url: " + url + ", trying to get from server");
+                $.get(url, function(data) {
+                    console.log("Found data on server for url: " + url);
+                    callback(data);                    
                 }).fail(function(error) {
                     if (error.status === 404) {
                         console.debug('No matching object on server');
@@ -62,8 +51,7 @@ clusiveAssessment.setUpCompCheck = function() {
                         console.warn('failed to get data: ', error.status);
                     }
                 });
-            }
-        }                
+            }                
     };
 
 
@@ -76,7 +64,7 @@ clusiveAssessment.setUpCompCheck = function() {
     // Retrieve existing affect check values and set them
 
     var set_affect_check = function(data) {
-        Object.keys(affect_check_data).forEach(function (affectOptionName) {
+        Object.keys(data).forEach(function (affectOptionName) {
             var shouldCheck = data[affectOptionName];
             var affectInput = $('input[name="' + affectOptionName + '"]');
             affectInput.prop("checked", shouldCheck);

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -28,6 +28,13 @@ clusiveAssessment.showCompCheck = function() {
 clusiveAssessment.setUpCompCheck = function() {
     'use strict';
 
+    var autosaveQueue = clusive.djangoMessageQueue({
+        config: {                        
+            localStorageKey: "clusive.messageQueue.autosave",
+            lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
+        }
+    });
+
     var bookId = clusiveContext.reader.info.publication.id;
 
     // Block auto-show for at least 10 seconds after page load, to prevent it erroneously getting shown.
@@ -109,20 +116,23 @@ clusiveAssessment.setUpCompCheck = function() {
                 affectResponse[elem.name] = elem.checked
             });
 
-            $.ajax('/assessment/affect_check', {
-                method: 'POST',
-                headers: {
-                    'X-CSRFToken': DJANGO_CSRF_TOKEN
-                },
-                data: JSON.stringify(affectResponse)
-            })
-                .done(function(data) {
-                    console.debug('Affect check save complete', data);
-                    clusiveAssessment.affectCheckDone = true;
-                })
-                .fail(function(err) {
-                    console.error('Affect check save failed!', err);
-                });
+
+            autosaveQueue.add({"type": "AS", "url": "/assessment/affect_check", "data": JSON.stringify(affectResponse)});
+
+            // $.ajax('/assessment/affect_check', {
+            //     method: 'POST',
+            //     headers: {
+            //         'X-CSRFToken': DJANGO_CSRF_TOKEN
+            //     },
+            //     data: JSON.stringify(affectResponse)
+            // })
+            //     .done(function(data) {
+            //         console.debug('Affect check save complete', data);
+            //         clusiveAssessment.affectCheckDone = true;
+            //     })
+            //     .fail(function(err) {
+            //         console.error('Affect check save failed!', err);
+            //     });
 
             var scaleResponse = $('input[name="comprehension-scale"]:checked').val();
             var freeResponse = $('textarea[name="comprehension-free"]').val();

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -102,6 +102,12 @@ clusiveAssessment.setupAssessments = function() {
 
     clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
 
+    window.setInterval(function() {
+        console.log("adding current state of assessments to autosave queue")
+        clusiveAssessment.saveAffectCheck();
+        clusiveAssessment.saveComprehensionCheck();        
+    }, 15000)
+
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(
         function() {
@@ -116,19 +122,7 @@ clusiveAssessment.setupAssessments = function() {
                 $('#comprehensionFreeResponseArea').show();
             }
         }
-    );
-
-    // When submit button is clicked, build JSON and send to server, close popover.
-    $('#comprehensionCheckSubmit').click(
-        function(e) {
-            e.preventDefault();
-
-            clusiveAssessment.saveAffectCheck();
-
-            clusiveAssessment.saveComprehensionCheck();                  
-
-            $(this).closest('.popover').CFW_Popover('hide');
-        });
+    );  
 };
 
 $(function() {

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -49,7 +49,7 @@ clusiveAssessment.setUpCompCheck = function() {
                 });
                 
                 if(autosaveMessages.length > 0) {                    
-                    var latestLocalData = autosaveMessages.pop().content.data;
+                    var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
                     console.log("local data for url: " + url + " found");
                     callback(latestLocalData);
                 } else {                   
@@ -103,8 +103,8 @@ clusiveAssessment.setUpCompCheck = function() {
     var set_comprehension_check = function(data) {
         console.log("calling set_comprehension_check", data);
         clusiveAssessment.compCheckDone = true;
-        var scaleResponse = data.scale_response;
-        var freeResponse = data.free_response;
+        var scaleResponse = data.scaleResponse;
+        var freeResponse = data.freeResponse;
         $('textarea[name="comprehension-free"]').val(freeResponse);
         $('input[name="comprehension-scale"]').val([scaleResponse]);
         $('input[name="comprehension-scale"]').change();

--- a/src/frontend/js/assessment.js
+++ b/src/frontend/js/assessment.js
@@ -102,13 +102,12 @@ clusiveAssessment.setupAssessments = function() {
     clusiveAutosave.retrieve('/assessment/affect_check/' + bookId, clusiveAssessment.setAffectCheck);
 
     clusiveAutosave.retrieve('/assessment/comprehension_check/' + bookId, clusiveAssessment.setComprehensionCheck);
-
-    // TODO: this should be an onchange on the elements
+    
     window.setInterval(function() {
         console.log("adding current state of assessments to autosave queue")
         clusiveAssessment.saveAffectCheck();
         clusiveAssessment.saveComprehensionCheck();        
-    }, 1000)
+    }, 15000)
 
     // When a radio button is selected, show the appropriate free-response prompt.
     $('input[name="comprehension-scale"]').change(

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -11,6 +11,10 @@ var clusiveAutosave = {
         }),
     // Test if data is equivalent for autosave purposes        
     isEquivalentData: function (oldData, newData) {
+        // Null guard
+        if(!oldData || !newData) {
+            return false;
+        }
         var isEquivalent = true;
         Object.keys(newData).forEach(function (key) {
             if(newData[key] !== oldData[key]) {
@@ -23,8 +27,7 @@ var clusiveAutosave = {
         return isEquivalent;                
     },
     save: function(url, data) {        
-        var lastData = clusiveAutosave.lastDataCache[url];
-        // TODO: Only check that same keys with same values exist
+        var lastData = clusiveAutosave.lastDataCache[url];        
         var isNewData = !clusiveAutosave.isEquivalentData(lastData, data);                
         if(isNewData) {
             console.log("adding changed data to autosave queue");

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -10,16 +10,18 @@ var clusiveAutosave = {
             }
         }),
     // Test if data is equivalent for autosave purposes        
-    isEquivalentData: function (oldData, newData) {        
-        var isEquivalent = true;
+    isEquivalentData: function (oldData, newData) {                
         if(!oldData || !newData) {
-            isEquivalent = false;
+            return false;
         }
+        var isEquivalent = true;
+
         Object.keys(newData).forEach(function (key) {
             if(newData[key] !== oldData[key]) {                
                 isEquivalent = false;                
             }
-        });        
+        }); 
+               
         return isEquivalent;                
     },
     save: function(url, data) {        

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -1,0 +1,42 @@
+/* Code for comprehension and affect assessments */
+/* global clusive, clusiveContext, PAGE_EVENT_ID, DJANGO_CSRF_TOKEN, fluid, D2Reader */
+/* exported clusiveAutosave */
+
+var clusiveAutosave = {
+    queue: clusive.djangoMessageQueue({
+            config: {                        
+                localStorageKey: "clusive.messageQueue.autosave",
+                lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
+            }
+        }),
+    set: function(url, data) {
+        clusiveAutosave.queue.add({"type": "AS", "url": url, "data": data});
+    },
+    retrieve: 
+        function(url, callback) {
+            var hasLocal = false;                
+            var autosaveMessages = [].concat(clusiveAutosave.queue.getMessages()).filter(function (item) {                    
+                    if(item.content.type === "AS" && item.content.url === url) {
+                        return true;
+                    }                    
+            });
+            
+            if(autosaveMessages.length > 0) {                                        
+                var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
+                console.log("local data for url: " + url + " found", latestLocalData);
+                callback(latestLocalData);
+            } else {                   
+                console.log("No local data for url: " + url + ", trying to get from server");
+                $.get(url, function(data) {
+                    console.log("Found data on server for url: " + url);
+                    callback(data);                    
+                }).fail(function(error) {
+                    if (error.status === 404) {
+                        console.debug('No matching data on server for url: ' + url);
+                    } else {
+                        console.warn('failed to get data: ', error.status);
+                    }
+                });
+            }                 
+        }                
+};

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -9,10 +9,23 @@ var clusiveAutosave = {
                 lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
             }
         }),
+    // Test if data is equivalent for autosave purposes        
+    isEquivalentData: function (oldData, newData) {
+        var isEquivalent = true;
+        Object.keys(newData).forEach(function (key) {
+            if(newData[key] !== oldData[key]) {
+                console.log("comparison of values", newData[key], oldData[key]);
+                console.log("found differing values for " + key, newData[key], oldData[key]);
+                isEquivalent = false;                
+            }
+        });
+        console.log("isEquivalent", isEquivalent);
+        return isEquivalent;                
+    },
     save: function(url, data) {        
         var lastData = clusiveAutosave.lastDataCache[url];
-        var isNewData = (lastData !== data);        
-        console.log("comparison of data and lastData: ", data, lastData, isNewData);
+        // TODO: Only check that same keys with same values exist
+        var isNewData = !clusiveAutosave.isEquivalentData(lastData, data);                
         if(isNewData) {
             console.log("adding changed data to autosave queue");
             clusiveAutosave.queue.add({"type": "AS", "url": url, "data": JSON.stringify(data)});

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -10,31 +10,27 @@ var clusiveAutosave = {
             }
         }),
     // Test if data is equivalent for autosave purposes        
-    isEquivalentData: function (oldData, newData) {
-        // Null guard
-        if(!oldData || !newData) {
-            return false;
-        }
+    isEquivalentData: function (oldData, newData) {        
         var isEquivalent = true;
+        if(!oldData || !newData) {
+            isEquivalent = false;
+        }
         Object.keys(newData).forEach(function (key) {
-            if(newData[key] !== oldData[key]) {
-                console.log("comparison of values", newData[key], oldData[key]);
-                console.log("found differing values for " + key, newData[key], oldData[key]);
+            if(newData[key] !== oldData[key]) {                
                 isEquivalent = false;                
             }
-        });
-        console.log("isEquivalent", isEquivalent);
+        });        
         return isEquivalent;                
     },
     save: function(url, data) {        
         var lastData = clusiveAutosave.lastDataCache[url];        
         var isNewData = !clusiveAutosave.isEquivalentData(lastData, data);                
         if(isNewData) {
-            console.log("adding changed data to autosave queue");
+            console.debug("adding changed data for URL " + url + "to autosave queue: ", data);
             clusiveAutosave.queue.add({"type": "AS", "url": url, "data": JSON.stringify(data)});
             clusiveAutosave.lastDataCache[url] = data; 
         } else {
-            console.log("data has not changed, not adding to autosave queue");
+            console.debug("no changed data for URL " + url + ", not adding to autosave queue", data)
         }
     },
     retrieve: 
@@ -47,14 +43,12 @@ var clusiveAutosave = {
             });
             
             if(autosaveMessages.length > 0) {                                        
-                var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);
-                console.log("local data for url: " + url + " found", latestLocalData);
+                var latestLocalData = JSON.parse(autosaveMessages.pop().content.data);                
                 callback(latestLocalData);
                 clusiveAutosave.lastDataCache[url] = latestLocalData;
             } else {                   
-                console.log("No local data for url: " + url + ", trying to get from server");
-                $.get(url, function(data) {
-                    console.log("Found data on server for url: " + url);
+                console.debug("No local data for url: " + url + ", trying to get from server");
+                $.get(url, function(data) {                    
                     callback(data);                    
                     clusiveAutosave.lastDataCache[url] = data;
                 }).fail(function(error) {

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -9,7 +9,7 @@ var clusiveAutosave = {
                 lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
             }
         }),
-    set: function(url, data) {
+    save: function(url, data) {
         clusiveAutosave.queue.add({"type": "AS", "url": url, "data": data});
     },
     retrieve: 

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -3,7 +3,7 @@
 /* exported clusiveAutosave */
 
 var clusiveAutosave = {
-    queue: clusive.djangoMessageQueue({
+    messageQueue: clusive.djangoMessageQueue({
             config: {                        
                 localStorageKey: "clusive.messageQueue.autosave",
                 lastQueueFlushInfoKey: "clusive.messageQueue.autosave.log.lastQueueFlushInfo"
@@ -21,7 +21,7 @@ var clusiveAutosave = {
                 isEquivalent = false;                
             }
         }); 
-               
+
         return isEquivalent;                
     },
     save: function(url, data) {        
@@ -29,7 +29,7 @@ var clusiveAutosave = {
         var isNewData = !clusiveAutosave.isEquivalentData(lastData, data);                
         if(isNewData) {
             console.debug("adding changed data for URL " + url + "to autosave queue: ", data);
-            clusiveAutosave.queue.add({"type": "AS", "url": url, "data": JSON.stringify(data)});
+            clusiveAutosave.messageQueue.add({"type": "AS", "url": url, "data": JSON.stringify(data)});
             clusiveAutosave.lastDataCache[url] = data; 
         } else {
             console.debug("no changed data for URL " + url + ", not adding to autosave queue", data)
@@ -38,7 +38,7 @@ var clusiveAutosave = {
     retrieve: 
         function(url, callback) {
             var hasLocal = false;                
-            var autosaveMessages = [].concat(clusiveAutosave.queue.getMessages()).filter(function (item) {                    
+            var autosaveMessages = [].concat(clusiveAutosave.messageQueue.getMessages()).filter(function (item) {                    
                     if(item.content.type === "AS" && item.content.url === url) {
                         return true;
                     }                    

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -65,6 +65,5 @@ var clusiveAutosave = {
         },
     // Maintains per-url record of data to avoid unneeded autosaving
     lastDataCache: {
-
     }
 };

--- a/src/frontend/js/clusive-autosave.js
+++ b/src/frontend/js/clusive-autosave.js
@@ -33,9 +33,8 @@ var clusiveAutosave = {
             // Test if we should replace an existing autosave message
             // TODO: this functionality should be ported over to the message queue,
             // should the need for it arise outside the autosave
-            
-            var currentPosition = clusiveAutosave.messageQueue.getMessages().findIndex(function (message) {
-                console.log("testing for message for URL: ", url, message);
+
+            var currentPosition = clusiveAutosave.messageQueue.getMessages().findIndex(function (message) {                
                 if(message.content.type === "AS" && message.content.url === url) {                    
                     return true;
                 }                
@@ -55,8 +54,7 @@ var clusiveAutosave = {
         }
     },
     retrieve: 
-        function(url, callback) {
-            var hasLocal = false;                
+        function(url, callback) {                    
             var autosaveMessages = [].concat(clusiveAutosave.messageQueue.getMessages()).filter(function (item) {                    
                     if(item.content.type === "AS" && item.content.url === url) {
                         return true;

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,13 @@ import execGPIIBinder from "script-loader!fluid-binder/src/js/binder.js";
 
 // Files from src/frontend:
 
+import execClusiveMessageQueue from "script-loader!../src/frontend/js/clusive-message-queue.js"
+import execClusiveDjangoMessageQueue from "script-loader!../src/frontend/js/clusive-django-message-queue.js"
+import execClusiveAutosave from "script-loader!../src/frontend/js/clusive-autosave.js";
 import execClusiveContext from "script-loader!../src/frontend/js/clusive-context.js";
 import execClusiveEventsCaliper from "script-loader!../src/frontend/js/clusive-events-caliper.js"
 import execClusiveReaderPrefs from "script-loader!../src/frontend/js/clusive-reader-prefs.js";
 import execClusivePrefsPanel from "script-loader!../src/frontend/js/clusive-prefs-panel.js";
-import execClusiveMessageQueue from "script-loader!../src/frontend/js/clusive-message-queue.js"
-import execClusiveDjangoMessageQueue from "script-loader!../src/frontend/js/clusive-django-message-queue.js"
 import execClusivePrefsDjangoStore from "script-loader!../src/frontend/js/clusive-prefs-django-store.js"
 import execClusivePrefsModalSettings from "script-loader!../src/frontend/js/clusive-prefs-modal-settings.js"
 import execAssessment from "script-loader!../src/frontend/js/assessment.js";

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ import execGPIIBinder from "script-loader!fluid-binder/src/js/binder.js";
 
 // Files from src/frontend:
 
-import execAssessment from "script-loader!../src/frontend/js/assessment.js";
 import execClusiveContext from "script-loader!../src/frontend/js/clusive-context.js";
 import execClusiveEventsCaliper from "script-loader!../src/frontend/js/clusive-events-caliper.js"
 import execClusiveReaderPrefs from "script-loader!../src/frontend/js/clusive-reader-prefs.js";
@@ -34,6 +33,7 @@ import execClusiveMessageQueue from "script-loader!../src/frontend/js/clusive-me
 import execClusiveDjangoMessageQueue from "script-loader!../src/frontend/js/clusive-django-message-queue.js"
 import execClusivePrefsDjangoStore from "script-loader!../src/frontend/js/clusive-prefs-django-store.js"
 import execClusivePrefsModalSettings from "script-loader!../src/frontend/js/clusive-prefs-modal-settings.js"
+import execAssessment from "script-loader!../src/frontend/js/assessment.js";
 import execFrontEnd from "script-loader!../src/frontend/js/frontend.js"
 import execGlossary from "script-loader!../src/frontend/js/glossary.js"
 import execImages from "script-loader!../src/frontend/js/images.js"

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -47,10 +47,8 @@ class Message:
 
     def send_autosave(self):
         logger.debug("autosave request received: %s", self.content)
-        associated_view = resolve(self.content['url'])
-        # logger.debug("self.content['data'] 1: %s", self.content['data'])
-        associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))
-        # logger.debug("self.content['data'] 2: %s", self.content['data'])        
+        associated_view = resolve(self.content['url'])        
+        associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))        
 
     def send_client_side_prefs_change(self):
         client_side_prefs_change.send(sender=self.__class__, timestamp=self.timestamp, content=self.content, request=self.request)

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -2,6 +2,10 @@ from enum import Enum
 
 from django.db import models
 
+from django.urls import resolve
+
+import json
+
 import django.dispatch
 
 from eventlog.signals import control_used, page_timing
@@ -20,6 +24,7 @@ class Message:
         CALIPER_EVENT = 'CE'
         PAGE_TIMING = 'PT'
         TIP_RELATED_ACTION = 'TRA'
+        AUTOSAVE = 'AS'
 
     def __init__(self, message_type, timestamp, content, request):
         # This will raise ValueError if the given type is not in AllowedTypes
@@ -37,6 +42,15 @@ class Message:
             self.send_page_timing()
         if self.type == Message.AllowedTypes.TIP_RELATED_ACTION:
             self.send_tip_related_action()
+        if self.type == Message.AllowedTypes.AUTOSAVE:
+            self.send_autosave()
+
+    def send_autosave(self):
+        logger.debug("autosave request received: %s", self.content)
+        associated_view = resolve(self.content['url'])
+        # logger.debug("self.content['data'] 1: %s", self.content['data'])
+        associated_view.func.view_class.create(self.request, json.loads(self.content['data']))
+        # logger.debug("self.content['data'] 2: %s", self.content['data'])        
 
     def send_client_side_prefs_change(self):
         client_side_prefs_change.send(sender=self.__class__, timestamp=self.timestamp, content=self.content, request=self.request)

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -47,8 +47,12 @@ class Message:
 
     def send_autosave(self):
         logger.debug("autosave request received: %s", self.content)
-        associated_view = resolve(self.content['url'])        
-        associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))        
+        try:
+            url = self.content['url']
+            associated_view = resolve(url)        
+            associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))        
+        except django.urls.exceptons.Resolver404:
+            logger.debug("autosave request had URL %s, but could not be resolved to a View", url)
 
     def send_client_side_prefs_change(self):
         client_side_prefs_change.send(sender=self.__class__, timestamp=self.timestamp, content=self.content, request=self.request)

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -49,9 +49,9 @@ class Message:
         logger.debug("autosave request received: %s", self.content)
         try:
             url = self.content['url']
-            associated_view = resolve(url)        
-            associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))        
-        except django.urls.exceptons.Resolver404:
+            associated_view = resolve(url)                    
+            associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']), **associated_view.kwargs)        
+        except django.urls.exceptions.Resolver404:
             logger.debug("autosave request had URL %s, but could not be resolved to a View", url)
 
     def send_client_side_prefs_change(self):

--- a/src/messagequeue/models.py
+++ b/src/messagequeue/models.py
@@ -49,7 +49,7 @@ class Message:
         logger.debug("autosave request received: %s", self.content)
         associated_view = resolve(self.content['url'])
         # logger.debug("self.content['data'] 1: %s", self.content['data'])
-        associated_view.func.view_class.create(self.request, json.loads(self.content['data']))
+        associated_view.func.view_class.create_from_request(self.request, json.loads(self.content['data']))
         # logger.debug("self.content['data'] 2: %s", self.content['data'])        
 
     def send_client_side_prefs_change(self):

--- a/src/shared/templates/shared/partial/popover_comp.html
+++ b/src/shared/templates/shared/partial/popover_comp.html
@@ -145,8 +145,7 @@
                         <textarea id="compText0" class="form-control" name="comprehension-free"></textarea>
                         <a href="#" role="button" class="stt-btn" data-cast="stt" data-target="#compText0"><span class="icon-mic" aria-hidden="true"></span><span class="sr-only">Use Speech to Text</span></a>
                     </div>
-                </div>
-                <button type="button" class="btn btn-primary" id="comprehensionCheckSubmit">Save</button>
+                </div>                
             </form>
         </div>
     </div>


### PR DESCRIPTION
This implements a general autosave pattern using the existing message queue system, and uses it to replace the manual save in the assessments pop-up.

Key files:
- `frontend/js/clusive-autosave.js`: provides an autosave interface with `save` and `retrieve` methods that use REST-ful URLs as keys (using code doesn't need to know if it's dealing with local or server data)
- `frontend/js/assessments.js`: uses the autosave code
- `messagequeue/models.py`: uses `django.urls.resolve` to match REST-ful URLs to appropriate View methods
- `assessments/views.py`: extracts `create_from_request` methods used by the autosave code