### PR TITLE
CSL-1010: Remove Google classroom roster scope from SSO sign-up

### DIFF
--- a/src/clusive_project/settings.py
+++ b/src/clusive_project/settings.py
@@ -59,8 +59,7 @@ SOCIALACCOUNT_PROVIDERS = {
         'SCOPE': [
             'profile',
             'email',
-            'openid',
-            'https://www.googleapis.com/auth/classroom.rosters.readonly',
+            'openid'
         ],
         'AUTH_PARAMS': {
             # for automatically refresh access token, see:


### PR DESCRIPTION
@bgoldowsky - ready for review.

This was much easier than anticipated -- I expected to have to fiddle with the database, but it's just one line in the settings.  Anyway, it's done, unless you see something I missed.

JIRA: https://castudl.atlassian.net/browse/CSL-1010
