### PR TITLE
CSL-1089: make readerPreferencesBridge user settings application nullsafe

### DIFF
--- a/src/frontend/js/clusive-reader-prefs.js
+++ b/src/frontend/js/clusive-reader-prefs.js
@@ -185,7 +185,7 @@
     cisl.prefs.readerPreferencesBridge.applyUserSetting = function(settingName, settingValue) {
         console.debug('applyUserSetting: ', settingName, settingValue);
         var reader = clusiveContext.reader.instance;
-        if (reader.applyUserSettings) {
+        if (reader && reader.applyUserSettings) {
             var settingsObj =
             {
                 [settingName]:settingValue
@@ -198,7 +198,7 @@
     cisl.prefs.readerPreferencesBridge.applyUserTTSSetting = function(ttsSettingName, settingValue) {
         console.debug("cisl.prefs.readerPreferencesBridge.applyUserTTSSetting", ttsSettingName, settingValue)
         var reader = clusiveContext.reader.instance;
-        if (reader) {
+        if (reader && reader.applyUserSettings) {
             var settingsObj =
             {
                 [ttsSettingName]:settingValue


### PR DESCRIPTION
Small change (thanks @mbrambilla for identifying) that fixes several reported bug in preference application.

Should fix the following reported bugs (tested on dev environment):
- https://castudl.atlassian.net/browse/CSL-1089
- https://castudl.atlassian.net/browse/CSL-1090
- https://castudl.atlassian.net/browse/CSL-1091
- https://castudl.atlassian.net/browse/CSL-995
- https://castudl.atlassian.net/browse/CSL-996