### PR TITLE
CSL-1092: page timing event tracking when using browser-cached page

### DIFF
--- a/src/eventlog/signals.py
+++ b/src/eventlog/signals.py
@@ -38,45 +38,17 @@ def log_page_timing(sender, **kwargs):
     Collects and stores page timing information, which the client may send at the end of a page view.
     The extra information will be added in to the original VIEWED event representing the page view.
     """
-
-    # update the active time of relevant paradata based on a supplied event and 
-    # time
-    def update_active_times(event, added_time):
-        # Page view events are used to calculate various totals.
-        if event.type == 'VIEW_EVENT' and event.action == 'VIEWED':
-            UserStats.add_active_time(event.actor, added_time)
-            if event.session is not None:
-                event.session.add_active_time(added_time)
-            # For book page views, increment time spent in Book
-            if event.book_id is not None:
-                Paradata.record_additional_time(book_id=event.book_id, user=event.actor, time=added_time)
-
     event_id = kwargs['event_id']
     times = kwargs['times']
     if event_id:
         try:
-            event = Event.objects.get(id=event_id)            
-            if event.load_time is not None:
-                # or event.duration is not None \
-                # or event.active_duration is not None:
-                logger.warning('Not overwriting existing page load time info on event %s', event)
-            if event.duration or event.active_duration is not None:
-                logger.debug('Adding additional page timing duration to %s', event)
-                added_duration = times.get('duration')
-                added_active_duration = times.get('activeDuration')
-                if added_duration:
-                    logger.debug('Adding %sms to existing duration of %s', added_duration, event.duration)
-                    event.duration = event.duration + timedelta(milliseconds=added_duration)
-                    logger.debug('Updated duration: %s', event.duration)
-                if added_active_duration:
-                    logger.debug('Adding %sms to existing active_duration of %s', added_active_duration, event.active_duration)
-                    added_time = timedelta(milliseconds=added_active_duration)
-                    event.active_duration = event.active_duration + added_time
-                    logger.debug('Updated active_duration: %s', event.active_duration)
-                    update_active_times(event, added_time)                    
-                event.save()   
+            event = Event.objects.get(id=event_id)
+            if event.load_time is not None \
+                or event.duration is not None \
+                or event.active_duration is not None:
+                logger.warning('Not overwriting existing page timing info on event %s', event)
             else:
-                logger.debug('Adding new page timing to %s: %s', event, times)
+                logger.debug('Adding page timing to %s: %s', event, times)
                 load_time = times.get('loadTime')
                 duration = times.get('duration')
                 active_duration = times.get('activeDuration')
@@ -86,7 +58,14 @@ def log_page_timing(sender, **kwargs):
                     event.duration = timedelta(milliseconds=duration)
                 if active_duration:
                     event.active_duration = timedelta(milliseconds=active_duration)
-                    update_active_times(event, event.active_duration)                    
+                    # Page view events are used to calculate various totals.
+                    if event.type == 'VIEW_EVENT' and event.action == 'VIEWED':
+                        UserStats.add_active_time(event.actor, event.active_duration)
+                        if event.session is not None:
+                            event.session.add_active_time(event.active_duration)
+                        # For book page views, increment time spent in Book
+                        if event.book_id is not None:
+                            Paradata.record_additional_time(book_id=event.book_id, user=event.actor, time=event.active_duration)
                 event.save()
         except Event.DoesNotExist:
             logger.error('Received page timing for a non-existent event %s', event_id)

--- a/src/eventlog/signals.py
+++ b/src/eventlog/signals.py
@@ -42,13 +42,34 @@ def log_page_timing(sender, **kwargs):
     times = kwargs['times']
     if event_id:
         try:
-            event = Event.objects.get(id=event_id)
-            if event.load_time is not None \
-                or event.duration is not None \
-                or event.active_duration is not None:
-                logger.warning('Not overwriting existing page timing info on event %s', event)
+            event = Event.objects.get(id=event_id)            
+            if event.load_time is not None:
+                # or event.duration is not None \
+                # or event.active_duration is not None:
+                logger.warning('Not overwriting existing page load time info on event %s', event)
+            if event.duration or event.active_duration is not None:
+                logger.debug('Adding additional page timing duration to %s', event)
+                added_duration = times.get('duration')
+                added_active_duration = times.get('activeDuration')
+                if added_duration:
+                    logger.debug('Adding %s added_duration to existing duration of %s', added_duration, event.duration)
+                    event.duration = event.duration + timedelta(milliseconds=added_duration)
+                    logger.debug('Updated duration: %s', event.duration)
+                if added_active_duration:
+                    logger.debug('Adding %s added_active_duration to existing active_duration of %s', added_active_duration, event.active_duration)
+                    event.active_duration = event.active_duration + timedelta(milliseconds=added_active_duration)
+                    logger.debug('Updated active_duration: %s', event.active_duration)
+                    # Page view events are used to calculate various totals.
+                    if event.type == 'VIEW_EVENT' and event.action == 'VIEWED':
+                        UserStats.add_active_time(event.actor, timedelta(milliseconds=added_active_duration))
+                        if event.session is not None:
+                            event.session.add_active_time(timedelta(milliseconds=added_active_duration))
+                        # For book page views, increment time spent in Book
+                        if event.book_id is not None:
+                            Paradata.record_additional_time(book_id=event.book_id, user=event.actor, time=timedelta(milliseconds=added_active_duration))
+                event.save()   
             else:
-                logger.debug('Adding page timing to %s: %s', event, times)
+                logger.debug('Adding new page timing to %s: %s', event, times)
                 load_time = times.get('loadTime')
                 duration = times.get('duration')
                 active_duration = times.get('activeDuration')

--- a/src/eventlog/views.py
+++ b/src/eventlog/views.py
@@ -14,6 +14,8 @@ from django.views.decorators.cache import never_cache
 
 logger = logging.getLogger(__name__)
 
+# All views using EventMixin should never browser cache, so that
+# statistics are accurate
 @method_decorator(never_cache, name='get')
 class EventMixin(ContextMixin):
     """

--- a/src/eventlog/views.py
+++ b/src/eventlog/views.py
@@ -9,8 +9,12 @@ from eventlog.models import Event
 from library.models import BookVersion
 from roster.models import ResearchPermissions
 
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+
 logger = logging.getLogger(__name__)
 
+@method_decorator(never_cache, name='get')
 class EventMixin(ContextMixin):
     """
     Creates a VIEW_EVENT for this view, and includes the event ID in the context for client-side use.

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -376,8 +376,7 @@ class ReaderChooseVersionView(RedirectView):
         kwargs['version'] = v
         return super().get_redirect_url(*args, **kwargs)
 
-
-@method_decorator(never_cache, name='dispatch')
+# @method_decorator(never_cache, name='dispatch')
 class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, TemplateView):
     """Reader page showing a page of a book"""
     template_name = 'pages/reader.html'

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -9,8 +9,6 @@ from django.db.models import Sum
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView, RedirectView, CreateView
 from django.views.generic.base import ContextMixin
 from django.views.generic.edit import BaseCreateView
@@ -376,7 +374,6 @@ class ReaderChooseVersionView(RedirectView):
         kwargs['version'] = v
         return super().get_redirect_url(*args, **kwargs)
 
-# @method_decorator(never_cache, name='dispatch')
 class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, TemplateView):
     """Reader page showing a page of a book"""
     template_name = 'pages/reader.html'


### PR DESCRIPTION
Opening PR for discussion in tech meeting tomorrow, I think this is a simple possible solution to https://castudl.atlassian.net/browse/CSL-1092, but it needs to be validated as acceptable from a research statistics standpoint.

The high level change is that Page Timing events (sent from the client-side message queue system) now add their time to the `duration` and `active_duration` fields of an existing Event, rather than simply being rejected. The `load_time` field remains fixed to capture the initial render time of the page from the server.

Functionally, this means using the 'back' button or other means to return to a page via the browser history will generate additional duration and active duration for the initial page view event, but not a second page view event.

Questions:
- is this acceptable from a research statistics standpoint? 
- if it isn't, what do we need to capture that is missing? if we want to count going back through the history as a separate "view", could we add an increment on the original Event or similar as part of the Page Timing message?
- any potential side effects from this change that would be undesirable to research statistics or otherwise?