### PR TITLE
CSL-1088: Fix change-password authentication backend

### DIFF
--- a/src/roster/urls.py
+++ b/src/roster/urls.py
@@ -22,7 +22,8 @@ urlpatterns = [
          name='password_reset_done'),
     path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(
         template_name='roster/password_reset_confirm.html',
-        post_reset_login=True),
+        post_reset_login=True,
+        post_reset_login_backend='django.contrib.auth.backends.ModelBackend'),
          name='password_reset_confirm'),
     path('reset/done/', auth_views.PasswordResetCompleteView.as_view(
         template_name='roster/password_reset_complete.html'),


### PR DESCRIPTION
Possible fix for the server error reported in [CSL-1088](https://castudl.atlassian.net/browse/CSL-1088).

I ran into a similar problem when trying to change the password of one of my test accounts in my development environment, where the stack trace indicated a missing authentication backend.  This PR fixes that by specifying Django's `django.contrib.auth.backends.ModelBackend`.