### PR TITLE
CSL-1222 Simple confirm page with "OK" button when there are no changes to synchronize

### DIFF
--- a/src/roster/templates/roster/manage_review_google_sync_roster.html
+++ b/src/roster/templates/roster/manage_review_google_sync_roster.html
@@ -15,6 +15,7 @@
             </div>
         </div>
         <div class="form-group mb-1">
+            {% if any_changes %}
             <div class="table-scroll">
                 <table class="table table-divided table-roster">
                     <thead>
@@ -35,7 +36,7 @@
 
                                 {% comment %}
                                 Logic: not an existing user entails that
-                                in_period is  False, and remove and
+                                in_period is False, and remove and
                                 email_changed are both n/a,
                                 Else, if exists, but not in_period
                                 then remove and email_changed are n/a.
@@ -62,12 +63,12 @@
                     </tbody>
                 </table>
             </div>
-            {% if any_changes %}
             <a href="{% url 'google_roster_update' course_id=course_id period_id=current_period.pk %}" class="btn btn-secondary">Save changes</a>
-            {% else %}
-            <button type="button" class="btn btn-secondary" disabled>Save changes</button>
-            {% endif %}
             <a href="{% url 'manage' period_id=current_period.pk %}" class="btn btn-link">Cancel</a>
+            {% else %}
+            <p>Everything is up to date.</p>
+            <a href="{% url 'manage' period_id=current_period.pk %}" class="btn btn-secondary">OK</a>
+            {% endif %}
         </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
@bgoldowsky Here's a version of simple page that states there are no updates to the Google classroom roster and allows the user to proceed with an "OK" button.

The message might be improved; not sure.  I'll pose the question in the JIRA.

JIRA: https://castudl.atlassian.net/browse/CSL-1222?focusedCommentId=30403