### PR TITLE
NOJIRA: Fix the `djangoStore` exception on the About page

### DIFF
--- a/src/shared/templates/shared/base.html
+++ b/src/shared/templates/shared/base.html
@@ -12,7 +12,9 @@
     {% block head_additional %}{% endblock %}
 </head>
 <body class="{% block bodyClass %}{% endblock %} {{theme_class}}">
-    {% block preference_panel %} {% include "shared/partial/preference-panel.html" with prefs_is_reader=False %} {% endblock %}
+    {% if request.user.is_authenticated %}
+        {% block preference_panel %} {% include "shared/partial/preference-panel.html" with prefs_is_reader=False %} {% endblock %}
+    {% endif %}
     <a class="skiplink sr-only-focusable" href="#content">Skip to main content</a>
 
     {% block header %}


### PR DESCRIPTION
The "unresolved `{djangoStore}`" exception occurs only when there is no user logged in and this is due to the fluid preferences panel being included with the About page. The About page loads without issue when a user is logged in. Also, when no user is logged in, access to preferences is meaningless, so there is no need for a preferences panel in this case.

The solution is to conditionally include the panel only when there is a user logged in, checking `request.user.is_authenticated`. This is done in the base.html template, which is a bit worrisome, since it is the basis for most (all?) of Clusive's pages. I've tested three cases: no user logged in, an SSO user logged in, and a Guest user logged in. The preferences panel was included as appropriate. Also, this change removes the djangoStore exception.

@bgoldowsky @mbrambilla have a look, and if there is a better way to do it, let me know.