### PR TITLE
CSL-1370: Force a default TTS voice

### DIFF
--- a/src/frontend/js/clusive-prefs-modal-settings.js
+++ b/src/frontend/js/clusive-prefs-modal-settings.js
@@ -254,7 +254,9 @@
     cisl.prefs.modalSettings.handleReadVoicesPreference = function(readVoices, that) {
         console.debug("handleReadVoicesPreference", readVoices, that);
         if(! readVoices || ! readVoices.forEach || readVoices.length === 0) {
-            that.locate('readVoice').val('default').change();
+            //that.locate('readVoice').val('default').change();
+            var defaultVoice = clusiveTTS.getDefaultVoice();
+            that.locate('readVoice').val(defaultVoice).change();
             return;
         }
 
@@ -269,6 +271,9 @@
             //clusiveTTS.updateSettings({
             //    voice: preferredVoice
             //});
+        } else {
+            var defaultVoice = clusiveTTS.getDefaultVoice();
+            that.locate('readVoice').val(defaultVoice).change();
         }
     };
 

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -850,7 +850,7 @@ clusiveTTS.getDefaultVoice = function() {
     var langVoices = [];
 
     userLanguages.some(function(lang) {
-        if (lang.substring(0, 3) === 'en-') {
+        if (lang.startsWith('en-')) {
             langVoices = clusiveTTS.getVoicesForLanguage(lang);
             defaultVoice = langVoices.length > 0 ? langVoices[0] : null;
             if (defaultVoice !== null) {

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -850,7 +850,7 @@ clusiveTTS.getDefaultVoice = function() {
     var langVoices = [];
 
     userLanguages.some(function(lang) {
-        if (lang.substring(0, 1) === 'en' && lang.length > 3) {
+        if (lang.substring(0, 3) === 'en-') {
             langVoices = clusiveTTS.getVoicesForLanguage(lang);
             defaultVoice = langVoices.length > 0 ? langVoices[0] : null;
             if (defaultVoice !== null) {
@@ -870,7 +870,7 @@ clusiveTTS.getDefaultVoice = function() {
         defaultVoice = langVoices.length > 0 ? langVoices[0] : null;
     }
 
-    console.debug('setDefaultVoice', defaultVoice.name);
+    console.debug('getDefaultVoice', defaultVoice.name);
 
     return defaultVoice.name;
 };

--- a/src/shared/templates/shared/partial/modal_settings.html
+++ b/src/shared/templates/shared/partial/modal_settings.html
@@ -200,7 +200,10 @@
                                 <fieldset>
                                     <legend class="setting-title">Voice</legend>
                                     <select class="cislc-modalSettings-readVoice form-control">
+                                        {% comment %}
+                                        <!-- Hide 'default' value from user since we are forcing one -->
                                         <option value="default">Choose...</option>
+                                        {% endcomment %}
                                     </select>
                                 </fieldset>
                             </div>

--- a/src/shared/templates/shared/partial/modal_settings.html
+++ b/src/shared/templates/shared/partial/modal_settings.html
@@ -200,10 +200,6 @@
                                 <fieldset>
                                     <legend class="setting-title">Voice</legend>
                                     <select class="cislc-modalSettings-readVoice form-control">
-                                        {% comment %}
-                                        <!-- Hide 'default' value from user since we are forcing one -->
-                                        <option value="default">Choose...</option>
-                                        {% endcomment %}
                                     </select>
                                 </fieldset>
                             </div>


### PR DESCRIPTION
New implementation:

-  Assume base language of `en`
-  Check user/browser languages for region specific `en-*` variants - default to first voice on match based on order of preference - as reported by `navigator.languages`
- otherwise default to first `en-US` voice
- default to first `en` voice if no `en-US` voice available
-  Remove the 'Choose…' option from list since we are forcing a voice

I think it should cover most of our current/intended user base - there could be some issues for international users - but most language related-items are already hard-coded to an `en` base.  Testing on my environments seems to be working well otherwise.