### PR TITLE
NOJIRA: POC to move focus from TOC into reader frame

### DIFF
--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -528,6 +528,12 @@ console.log('TOC REFOCUS', TOC_focusSelector, event);
 
     var _getValidSelector = function(selector, rootElement) {
         if (typeof rootElement === 'undefined') { rootElement = document; }
+
+        // Split at #
+        if (selector.indexOf('#') > -1) {
+            selector = selector.substring(selector.indexOf('#'));
+        }
+console.log("SELECTOR", selector);
         try {
             return rootElement.querySelector(selector) ? selector : null;
         } catch (error) {
@@ -537,23 +543,32 @@ console.log('TOC REFOCUS', TOC_focusSelector, event);
     var readerIframe = document.querySelector('#D2Reader-Container iframe');
     var readerDocument = readerIframe.contentDocument || readerIframe.contentWindow.document;
     var readerBody = readerDocument.body;
-
     var selector = _getValidSelector(TOC_focusSelector, readerBody);
-    var focusElm = null;
+
+console.log("SELECTOR parsed", selector);
 
     setTimeout(function() {
         if (selector === null) {
             // No specific element - focus on body
 console.log('FOCUS BODY', readerBody);
-            readerIframe.focus();
-            readerBody.setAttribute('tabindex', -1);
-            //setTimeout(function() {
-                readerBody.focus();
-                //readerBody.removeAttribute('tabindex');
-            //});
+            setTimeout(function() {
+                //readerIframe.focus();
+                readerBody.setAttribute('tabindex', -1);
+                setTimeout(function() {
+                    readerBody.focus();
+                    //readerBody.removeAttribute('tabindex');
+                });
+            });
         } else {
-console.log('FOCUS ELEMENT', readerBody.querySelector(selector));
-            readerBody.querySelector(selector).focus();
+            var readerItem = readerBody.querySelector(selector);
+console.log('FOCUS ELEMENT', readerItem);
+            setTimeout(function() {
+                //readerIframe.focus();
+                readerItem.setAttribute('tabindex', -1);
+                setTimeout(function() {
+                    readerItem.focus();
+                });
+            });
         }
 
         TOC_focusSelector = null;

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -214,6 +214,10 @@ var manifest_path = "{{ manifest_path }}";
             api: {
                 resourceReady: function() {
                     console.debug("D2Reader finished loading the resource at: " + new Date());
+
+                    // Fire custom event
+                    $(document).trigger('resourceReady.d2reader');
+
                     $(document).ready(function () {
                         // Do things that only need to be done once
                         if(!firstResourceLoaded) {
@@ -251,6 +255,9 @@ var manifest_path = "{{ manifest_path }}";
                 //     console.debug('resourceAtStart');
                 // },
                 updateCurrentLocation: function (locator) {
+                    // Fire custom event
+                    $(document).trigger('updateCurrentLocation.d2reader');
+
                     // Grey out forward/back navigation buttons when necessary.
                     // This logic cannot be moved to resourceAtStart/resourceAtEnd since it also needs to know
                     // when you move away from the edge, so that the buttons can be re-enabled.


### PR DESCRIPTION
Accessibility feedback showed that screen reader does not move to the location within the text, and there is no feedback that something occurred, such as the content within the reader frame has updated and scrolled into view.

Testing with NVDA/Windows and VoiceOver/MacOS. 

- Both VoiceOver and NVDA simulate clicks when activating a link from within the TOC.  No good way of telling a simulated click apart from mouse/touch click so this would need to apply to all users, not just keyboard or screen reader users.
- At least one layer of setTimeout seems to be needed to move focus into the frame.  Current testing has two layers due to bouncing around ideas.
- `tabindex=-1` seems needed to get focus properly moved for the screen readers.
- NVDA can still get hung up reading portions of the Clusive wrapper, sometimes just the TOC button, before reading focus into the frame..

Not necessarily happy with how this works, but this shows it is somewhat possible.  This method seems 'dirty', and might need additional improvements made upstream.