### PR TITLE
NOJIRA: Adjust `.link-stretch` use in library cards

### DIFF
--- a/src/frontend/html/dashboard.html
+++ b/src/frontend/html/dashboard.html
@@ -145,7 +145,7 @@
                         <div class="library-grid dashboard-grid">
                             <div class="card card-library">
                                 <div class="card-header">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -614,7 +614,7 @@
                                 <div class="library-grid dashboard-grid">
                                     <div class="card card-library">
                                         <div class="card-header">
-                                            <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                            <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                             <div class="card-author">
                                                 by Firstname Lastname
                                             </div>
@@ -662,7 +662,7 @@
                                     </div>
                                     <div class="card card-library">
                                         <div class="card-header">
-                                            <a href="#" class="link-stretch"><h2 class="card-title">Some longer article title with question?</h2></a>
+                                            <h2 class="card-title"><a href="#" class="link-stretch">Some longer article title with question?</a></h2>
                                             <div class="card-author">
                                                 by Firstname Lastname
                                             </div>
@@ -710,7 +710,7 @@
                                     </div>
                                     <div class="card card-library">
                                         <div class="card-header">
-                                            <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                            <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                             <div class="card-author">
                                                 by Firstname Lastname
                                             </div>
@@ -762,7 +762,7 @@
                                 <div class="library-grid dashboard-grid">
                                     <div class="card card-library">
                                         <div class="card-header">
-                                            <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                            <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                             <div class="card-author">
                                                 by Firstname Lastname
                                             </div>

--- a/src/frontend/html/library-list.html
+++ b/src/frontend/html/library-list.html
@@ -190,10 +190,10 @@
                         </div>
                     </div>
                     <div class="card-col col-12 col-sm">
-                        <div class="card-header">
+                        <div class="card-header has-favorite">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -274,7 +274,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some longer article title with question?</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some longer article title with question?</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -322,7 +322,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -370,7 +370,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -422,7 +422,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some longer article title with question?</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some longer article title with question?</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>
@@ -465,7 +465,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col">
-                                    <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                                    <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                                     <div class="card-author">
                                         by Firstname Lastname
                                     </div>

--- a/src/frontend/html/library.html
+++ b/src/frontend/html/library.html
@@ -313,8 +313,8 @@
                 </div>
 
                 <div class="card card-library">
-                    <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                    <div class="card-header has-favorite">
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>
@@ -377,8 +377,8 @@
                     </div>
                 </div>
                 <div class="card card-library">
-                    <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some longer article title with question?</h2></a>
+                    <div class="card-header has-favorite">
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some longer article title with question?</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>
@@ -420,7 +420,7 @@
                 </div>
                 <div class="card card-library">
                     <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>
@@ -454,7 +454,7 @@
                 </div>
                 <div class="card card-library">
                     <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>
@@ -502,7 +502,7 @@
                 </div>
                 <div class="card card-library">
                     <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some longer article title with question?</h2></a>
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some longer article title with question?</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>
@@ -536,7 +536,7 @@
                 </div>
                 <div class="card card-library">
                     <div class="card-header">
-                        <a href="#" class="link-stretch"><h2 class="card-title">Some article title</h2></a>
+                        <h2 class="card-title"><a href="#" class="link-stretch">Some article title</a></h2>
                         <div class="card-author">
                             by Firstname Lastname
                         </div>

--- a/src/frontend/scss/site/_card.scss
+++ b/src/frontend/scss/site/_card.scss
@@ -52,7 +52,7 @@
 
     .link-stretch {
         &::after {
-            top: -$card-padding-y;
+            top: calc(-#{$card-padding-y} - 3px);
             right: -$card-padding-x;
             bottom: calc(-2rem + #{-$card-padding-y});
             left: -$card-padding-x;
@@ -61,6 +61,28 @@
 
 }
 .card-graph-title {
+    margin-bottom: .25rem;
+    @include font-size(.8125rem);
+}
+
+.card-question {
+    position: relative;
+    z-index: 2;
+
+    .link-stretch {
+        &::after {
+            top: calc(-#{$card-padding-y} - 3px);
+            right: -$card-padding-x;
+            bottom: -$card-padding-y;
+            left: -$card-padding-x;
+        }
+
+        &:hover::after {
+            background-color: rgba(0, 0, 0, .05);
+        }
+    }
+}
+.card-question-title {
     margin-bottom: .25rem;
     @include font-size(.8125rem);
 }
@@ -84,7 +106,8 @@
 .card-library {
     box-shadow: var(--CT_cardLibraryBoxShadow);
 
-    *:not(.card-graph):not(.card-graph-title) > .link-stretch {
+    .card-title a,
+    *:not(.card-graph):not(.card-graph-title):not(.card-question-title) > .link-stretch {
         color: inherit;
         text-decoration: none;
 
@@ -110,7 +133,7 @@
         }
     }
 
-    .card-title {
+    .has-favorite .card-title {
         margin-right: calc(1rem + .25rem + (.375rem + 1px) * 2);
     }
     .btn-starred {

--- a/src/library/templates/library/partial/library_card.html
+++ b/src/library/templates/library/partial/library_card.html
@@ -2,19 +2,21 @@
 <div class="card card-library">
     <div class="card-header">
         {% if unauthorized %}
-        <a href="#" data-cfw="tooltip" title="Not authorized to view">
-        {% else %}
-        <a href="{% url 'reader_default' book_id=book.id %}"
-           {% if link_stretch %}class="link-stretch"{% endif %}
-           {% if not direct_link %}onclick="vocabCheck.start(this, '{{ book.id }}'); return false;"{% endif %}>
-        {% endif %}
+        <span class="d-block" tabindex="0" data-cfw="tooltip" title="Not authorized to view">
             <h2 class="card-title">
-                {% if unauthorized %}
                 <span class="icon-block" title="Not authorized to view"></span>
-                {% endif %}
                 {{ book.title|highlight:query }}
             </h2>
-        </a>
+        </span>
+        {% else %}
+        <h2 class="card-title">
+            <a href="{% url 'reader_default' book_id=book.id %}"
+            {% if link_stretch %}class="link-stretch"{% endif %}
+            {% if not direct_link %}onclick="vocabCheck.start(this, '{{ book.id }}'); return false;"{% endif %}>
+                {{ book.title|highlight:query }}
+            </a>
+        </h2>
+        {% endif %}
         {% if book.author %}<div class="card-author">{{ book.author|highlight:query }}</div>{% endif %}
     </div>
     {% if book.cover %}

--- a/src/library/templates/library/partial/library_card_custom_question.html
+++ b/src/library/templates/library/partial/library_card_custom_question.html
@@ -1,8 +1,8 @@
 <div class="card-divider"></div>
 
 {% if custom_question_data.question %}
-<div class="card-graph">
-    <div class="card-graph-title">
+<div class="card-question">
+    <div class="card-question-title">
         <strong>Custom question</strong>
         (<a href="#" role="button" class="link-stretch" data-cfw="modal" data-cfw-modal-target="#{{custom_link_prefix}}-{{graph_link_serial}}"
             data-cle-handler="click" data-cle-control="dash_custom_detail" data-cle-value="{{book.id}}">details</a>)

--- a/src/library/templates/library/partial/library_card_list.html
+++ b/src/library/templates/library/partial/library_card_list.html
@@ -14,17 +14,28 @@
                 <div class="row">
                     <div class="col">
                         {% if unauthorized %}
-                        <a href="#" data-cfw="tooltip" title="Not authorized to view">
-                        {% else %}
-                        <a href="{% url 'reader_default' book_id=book.id %}"
-                           {% if link_stretch %}class="link-stretch"{% endif %}
-                           {% if not direct_link %}onclick="vocabCheck.start(this, '{{ book.id }}'); return false;"{% endif %}>
-                        {% endif %}
+                        <span class="d-block" tabindex="0" data-cfw="tooltip" title="Not authorized to view">
                             <h2 class="card-title">
-                            {% if unauthorized %}
-                            <span class="icon-block" title="Not authorized to view"></span>
-                            {% endif %}
-                            {{ book.title|highlight:query }}</h2></a>
+                                <span class="icon-block" title="Not authorized to view"></span>
+                                {{ book.title|highlight:query }}
+                            </h2>
+                        </span>
+                        {% elif link_stretch %}
+                        <a href="{% url 'reader_default' book_id=book.id %}"
+                            class="link-stretch"
+                            {% if not direct_link %}onclick="vocabCheck.start(this, '{{ book.id }}'); return false;"{% endif %}>
+                            <h2 class="card-title">
+                                {{ book.title|highlight:query }}
+                            </h2>
+                        </a>
+                        {% else %}
+                        <h2 class="card-title">
+                            <a href="{% url 'reader_default' book_id=book.id %}"
+                            {% if not direct_link %}onclick="vocabCheck.start(this, '{{ book.id }}'); return false;"{% endif %}>
+                                {{ book.title|highlight:query }}
+                            </a>
+                        </h2>
+                        {% endif %}
                         {% if book.author %}<div class="card-author">{{ book.author|highlight:query }}</div>{% endif %}
                     </div>
                     <div class="col-auto card-toggle">


### PR DESCRIPTION
- Restructured `.card-title` item for consistent markup across stretched and non-stretched versions
- Adjust template logic to reduce nested ifs for `.card-header`
- Update disabled link semantics for 'unauthorized' items
- Adjust card-title spacing to only have right margin when 'starred' control is present - only mockups currently - uses `.has-favorite` modifier on `.card-header`
- Adjust spacing/position for link-stretch used on graph and question items to consume correct area