### PR TITLE
NOJIRA: Resolve python `SyntaxWarning` for `is not`; use `!=` instead.

### DIFF
--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1164,7 +1164,7 @@ class ListCustomizationsView(LoginRequiredMixin, EventMixin, TemplateView):
         # If there are no customizations but the user has just cancelled adding
         # one, do not prompt them to add a new one again.  That would be an
         # infinite loop
-        if customizations.count() is not 0 or from_cancel_add:
+        if customizations.count() != 0 or from_cancel_add:
             self.extra_context = {
                 'book': book,
                 'customizations': customizations,


### PR DESCRIPTION
Python 3.8 warns against using `is` and `is not` for comparisons involving
literals such as `0` (zero), and requires the use of `==` or `!=` instead.
See:
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/