### PR TITLE
CSL-1582: Implement deletion of a customization.

### DIFF
--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -1031,7 +1031,7 @@ function initEditCustomizations () {
         deleteVocabularyWord(e);
     });
 
-    // "Add" button on the custom vocabulary word suggetsions dialog
+    // "Add" button on the custom vocabulary word suggestions dialog
     $('#add-words-from-suggestions').click(function (e) {
         $('#modalWordSuggestions [type="checkbox"]').each(addCustomVocabFromSuggestions);
     });
@@ -1173,6 +1173,14 @@ function addCustomVocabFromSuggestions (index, checkbox) {
     }
 };
 
+// Configure the "Delete this Customization?" confirmation popup.
+function configureConfirmDeletionPopup (e) {
+    $('#deleteCustomizationTitle').text($(e.currentTarget).attr('data-title'));
+    $('#deleteCustomizationSubmit').attr(
+        'href', $(e.currentTarget).attr('data-delete-url')
+    );
+};
+
 $(window).ready(function() {
     'use strict';
 
@@ -1210,6 +1218,7 @@ $(window).ready(function() {
     if (document.querySelector('.custom-vocabulary-editor') !== null) {
         initEditCustomizations();
     }
+    $('body').on('click', 'button.delete-customization', configureConfirmDeletionPopup);
     $('#importPendingModal').on('afterHide.cfw.modal', bookshareCancelImport);
     $('body').on('click', 'button.import-button', bookshareStartImportProcess);
 });

--- a/src/library/templates/library/list_customizations.html
+++ b/src/library/templates/library/list_customizations.html
@@ -27,7 +27,6 @@
             <h2 class="me-0_5">{{ c.title }}</h2>
             <a href="{% url 'edit_customization' pk=c.id %}">edit <span class="sr-only">{{ c.title }}</span></a>
         </div>
-
         <h3>Classes</h3>
         <div class="row row-cols-sm-2 row-cols-md-3 row-cols-lg-4">
             {% for p in c.periods.all %}
@@ -55,12 +54,16 @@
                 None
             {% endif %}
         </p>
+        <div class="row row-cols-sm-2 row-cols-md-3 row-cols-lg-4">
+            <button type="button" class="btn btn-primary btn-small delete-customization" data-title="{{ c.title }}" data-delete-url="{% url 'delete_customization' bk=c.book.id ck=c.id %}" data-cfw="modal" data-cfw-modal-target="#modalDeleteCustomization">Delete this Customization</button>
+        </div>
     </div>
     {% empty %}
     <em>No customizations for this book</em>
     {% endfor %}
 
     <p><a href="{% url 'customize_add' pk=book.id %}" class="btn btn-primary">Add a customization</a></p>
+    {% include "library/partial/modal_delete_customization.html" %}
 
 </main>
 {% endblock %}

--- a/src/library/templates/library/partial/modal_delete_customization.html
+++ b/src/library/templates/library/partial/modal_delete_customization.html
@@ -1,0 +1,21 @@
+<div id="modalDeleteCustomization" class="modal" aria-labelledby="modalConfirmDeleteTitle">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="modalConfirmDeleteTitle" class="modal-title">Delete Customization</h2>
+                {% include "shared/partial/dialog_tts.html" %}
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close" title="Close">
+                    <span class="icon-cancel-circled2" aria-hidden="true"></span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to permanently delete <em id="deleteCustomizationTitle">Customization</em>?</p>
+                <p>This action cannot be undone, and will also delete custom vocabulary words and the custom question you or anyone else has added for this reading.</p>
+            </div>
+            <div class="modal-footer">
+                <a id="deleteCustomizationSubmit" href="#" class="btn btn-secondary" onclick="">Delete</a>
+                <button type="button" class="btn btn-link" data-cfw-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Implemented the ability to delete a customization to the page that lists all of the customizations associated with an article:
- `Delete this Customization` buttons for each customization on the page,
- Confirmation popup dialog to allow user to confirm or cancel the deletion.

The UI is there for testing the implementation and could use some loving.

JIRA: https://castudl.atlassian.net/browse/CSL-1582
