### PR TITLE
CS-1646 Add starred filter for library books

### DIFF
--- a/src/library/templates/library/partial/library_collection_selector.html
+++ b/src/library/templates/library/partial/library_collection_selector.html
@@ -19,6 +19,11 @@
                         </li>
                         {% endfor %}
                         <li>
+                            <a href="{% url 'library' style=style sort=sort view='starred' %}"
+                               {% if current_view == 'starred' %}class="active" aria-current="true"{% endif %}>
+                            {{view_names.starred}}</a>
+                        </li>
+                        <li>
                             <a href="{% url 'library' style=style sort=sort view='public' %}"
                                {% if current_view == 'public' %}class="active" aria-current="true"{% endif %}>
                             {{view_names.public}}</a>

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 #   Changing the style leaves all the other parameters unchanged.
 #   The links in the style menu therefore have a JS helper to add the current filter and page to the URL.
 #   The ClusiveUser model holds a default for style.
-# VIEW (which should perhaps have been called "collection"): [public, mine, or period]
+# VIEW (which should perhaps have been called "collection"): [public, mine, starred, or period]
 #   This is the third part of the library URL
 #   If view is "period", there is a fourth part of the URL which is the specific period being viewed.
 #   Changing the view resets QUERY, FILTER, and PAGE to their defaults.
@@ -155,6 +155,11 @@ class LibraryDataView(LoginRequiredMixin, ListView):
             q = Book.objects.filter(assignments__period=self.period)
         elif self.view == 'mine':
             q = Book.objects.filter(owner=self.clusive_user)
+        elif self.view == 'starred':
+            # STARRED = books found in paradata where starred field is true for this user
+            q = Book.objects.filter(
+                Q(paradata__starred=True)
+                & Q(paradata__user=self.clusive_user))
         elif self.view == 'public':
             q = Book.objects.filter(owner=None)
         elif self.view == 'all':

--- a/src/roster/models.py
+++ b/src/roster/models.py
@@ -132,12 +132,14 @@ class LibraryViews:
     ALL = 'all'
     PUBLIC = 'public'
     MINE = 'mine'
+    STARRED = 'starred'
     PERIOD = 'period'
 
     CHOICES = [
         (ALL, 'All readings'),
         (PUBLIC, 'Public readings'),
         (MINE, 'My readings'),
+        (STARRED, 'Starred readings'),
         (PERIOD, 'Period assignments')
     ]
 


### PR DESCRIPTION
Questions: 

Starred books are not immediately taken out of the Starred List - view is not refreshed (could change mind and the book is gone).  Is this the correct behavior?

What is the order of the filter?  Order is: period, starred, public, my, all.  Is this ok?

Similar to my books, starred is a filter even when there are no starred readings.  Is this ok?