### PR TITLE
CSL-1750: Add 'Comic Neue' for users without 'Comic Sans'

### DIFF
--- a/src/frontend/js/clusive-reader-prefs.js
+++ b/src/frontend/js/clusive-reader-prefs.js
@@ -56,7 +56,7 @@
                         },
                         {
                             inputValue: 'comic',
-                            outputValue: 'Comic Sans MS, sans-serif'
+                            outputValue: 'Comic Sans MS, Comic Sans, Comic Neue, cursive'
                         }, {
                             inputValue: 'open-dyslexic',
                             outputValue: 'OpenDyslexicRegular'

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -13,9 +13,11 @@ body {
 .ff-times {
     font-family: Georgia, Times, "Times New Roman", serif !important;
 }
+.fl-font-comic-sans:not([class*='icon']),
+.fl-font-comic-sans *:not([class*='icon']), // Override Infusion
 #ff-comic,
 .ff-comic {
-    font-family: "Comic Sans MS", sans-serif !important;
+    font-family: "Comic Sans MS", "Comic Sans", "Comic Neue", cursive !important;
 }
 #ff-arial,
 .ff-arial {

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -98,6 +98,7 @@ var simplificationTool = "{{ simplification_tool }}";
         var injectables = [
             {type: 'script', url: 'https://code.jquery.com/jquery-3.5.1.min.js'},
             {type: 'script', url: '{% static "shared/js/lib/internal.js" %}'},
+            {type: 'style', url: 'https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700', r2before: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-before.css" %}', r2before: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-default.css" %}', r2default: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-after.css" %}', r2after: true},
@@ -106,7 +107,7 @@ var simplificationTool = "{{ simplification_tool }}";
             {type: 'style', systemFont: true, fontFamily: 'Arial, Helvetica'},
             {type: 'style', systemFont: true, fontFamily: 'Georgia, Times, Times New Roman, serif'},
             {type: 'style', systemFont: true, fontFamily: 'Verdana'},
-            {type: 'style', systemFont: true, fontFamily: 'Comic Sans MS, sans-serif'},
+            {type: 'style', systemFont: true, fontFamily: 'Comic Sans MS, Comic Sans, Comic Neue, cursive'},
             {type: 'style', url: '{% static "shared/css/clusive-reader-theme-sepia.min.css" %}', r2after: true, appearance: 'clusive-sepia'},
             {type: 'style', url: '{% static "shared/css/clusive-reader-theme-night.min.css" %}', r2after: true, appearance: 'clusive-night'},
             // {type:'script', url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_CHTML&latest'},

--- a/src/shared/templates/shared/partial/head_styles.html
+++ b/src/shared/templates/shared/partial/head_styles.html
@@ -1,5 +1,8 @@
 {% load static %}
-<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+
 <link href="{% static 'shared/font/fontello/fontello.min.css' %}" rel="stylesheet">
 <link href="{% static 'shared/js/lib/reader/fonts/open-dyslexic/open-dyslexic-regular.css' %}" rel="stylesheet">
 


### PR DESCRIPTION
Android and iOS devices do not have a Comic font in their base install, this adds the Google Font 'Comic Neue' to the font stack
https://fonts.google.com/specimen/Comic+Neue