### PR TITLE
CSL-1690: Fix visuals and duplication of action menu on library cards

### DIFF
--- a/src/library/templates/library/partial/library_card.html
+++ b/src/library/templates/library/partial/library_card.html
@@ -40,7 +40,7 @@
     <div class="card-footer">
         <div class="row">
             {% include 'library/partial/library_card_topics.html' %}
+            {% include 'library/partial/library_teacher_extra_info.html' %}
         </div>
-        {% include 'library/partial/library_teacher_extra_info.html' %}
     </div>
 </div>

--- a/src/library/templates/library/partial/library_card_list.html
+++ b/src/library/templates/library/partial/library_card_list.html
@@ -58,13 +58,8 @@
                 <div class="card-footer">
                     <div class="row">
                         {% include 'library/partial/library_card_topics.html' %}
-                        {% if book.owner == request.clusive_user or request.clusive_user.can_manage_periods %}
-                        <div class="col-auto card-library-action">
-                            {% include "library/partial/library_action_menu.html" %}
-                        </div>
-                        {% endif %}
+                        {% include 'library/partial/library_teacher_extra_info.html' %}
                     </div>
-                    {% include 'library/partial/library_teacher_extra_info.html' %}
                 </div>
             </div>
         </div>

--- a/src/library/templates/library/partial/library_teacher_extra_info.html
+++ b/src/library/templates/library/partial/library_teacher_extra_info.html
@@ -2,9 +2,11 @@
 
 {% if show_assignments %}
     {% if book.assign_list or book.custom_list %}
-        <div class="card-divider spaced-top"></div>
-    {% endif %}
+    </div>
+    <div class="card-divider spaced-top"></div>
+    {% if book.assign_list %}
     {% include 'library/partial/library_teacher_assign_list.html' %}
+    {% endif %}
     <div class="row">
         <div class="col">
             {% if book.custom_list %}
@@ -16,10 +18,6 @@
             </div>
             {% endif %}
         </div>
-        {% include 'library/partial/library_action_menu.html' %}
-    </div>
-{% else %}
-    <div class="row">
-        {% include 'library/partial/library_action_menu.html' %}
-    </div>
+    {% endif %}
 {% endif %}
+{% include 'library/partial/library_action_menu.html' %}


### PR DESCRIPTION
Fixed the duplication and normalized the layout for the menu button across card variants.

If a reading has not been assigned or customized the menu will appear next to the topics.  Once assigned or customized the menu button will be under the divider and next to the assigned/customized indicators.

![Screenshot 2022-04-27 135557](https://user-images.githubusercontent.com/4764134/165589860-b77ee47f-dfe2-420d-9f1e-4157ccc86e16.png)

![Screenshot 2022-04-27 135529](https://user-images.githubusercontent.com/4764134/165589872-8b01d327-d18f-495f-9812-5657b1c59563.png)
