### PR TITLE
CSL-1515: TOC and Highlight items move focus to reader when clicked

### DIFF
--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -138,28 +138,31 @@ function buildTableOfContents() {
 
     if (typeof d2reader === 'object') {
         var items = d2reader.tableOfContents;
-        var has_structure = items.length > 1;
+        var has_structure = items.length > 0;
         if (items.length === 1 && items[0].children && items[0].children.length > 1) {
             has_structure = true;
         }
-        if (has_structure) {
-            $(TOC_EMPTY).hide();
-            var out = buildTocLevel(items, 0, 'toc');
-            $(TOC_CONTAINER).html(out).CFW_Init();
-
-            var navLinks = $(TOC_CONTAINER).find('.nav-link');
-            // Add click event to update menu when new page selected
-            navLinks.on('click', function() {
-                // Use timeout delay until we can get a callback from reader
-                setTimeout(function() {
-                    resetCurrentTocItem(false);
-                    markTocItemActive();
-                }, 100);
-            });
-        } else {
-            // Empty TOC
-            $(TOC_CONTAINER).hide();
+        if (!has_structure) {
+            // Use title and locator to create a single entry
+            items = [{
+                title: document.querySelector('#tocPubTitle').innerHTML,
+                href: d2reader.currentLocator.href
+            }];
         }
+
+        var out = buildTocLevel(items, 0, 'toc');
+        $(TOC_EMPTY).hide();
+        $(TOC_CONTAINER).html(out).CFW_Init();
+
+        var navLinks = $(TOC_CONTAINER).find('.nav-link');
+        // Add click event to update menu when new page selected
+        navLinks.on('click', function() {
+            // Use timeout delay until we can get a callback from reader
+            setTimeout(function() {
+                resetCurrentTocItem(false);
+                markTocItemActive();
+            }, 100);
+        });
     } else {
         console.warn('d2reader not initialized');
     }

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -139,9 +139,6 @@ function buildTableOfContents() {
     if (typeof d2reader === 'object') {
         var items = d2reader.tableOfContents;
         var has_structure = items.length > 0;
-        if (items.length === 1 && items[0].children && items[0].children.length > 1) {
-            has_structure = true;
-        }
         if (!has_structure) {
             // Use title and locator to create a single entry
             items = [{
@@ -156,7 +153,18 @@ function buildTableOfContents() {
 
         var navLinks = $(TOC_CONTAINER).find('.nav-link');
         // Add click event to update menu when new page selected
-        navLinks.on('click', function() {
+        navLinks.on('click', function(event) {
+            // Accessibility addition to close TOC and move focus to selected item within the reader frame.
+            // Uses click event because screen readers since they use simulated click events,
+            // even if keyboard navigation is used.
+            if (event) {
+                var selector = event.target.getAttribute('href') || '';
+                if (selector.length !== 0) {
+                    TOC_focusSelector = selector;
+                    $(TOC_MODAL).CFW_Modal('hide');
+                }
+            }
+
             // Use timeout delay until we can get a callback from reader
             setTimeout(function() {
                 resetCurrentTocItem(false);
@@ -460,21 +468,6 @@ function setUpNotes() {
     });
 }
 
-// Accessibility addition to close TOC and move focus to selected item within the reader frame.
-// Uses click event because screen readers since they use simulated click events,
-// even if keyboard navigation is used.
-function tocClickHandler() {
-    'use strict';
-
-    $(TOC_CONTAINER).on('click', 'a:not([data-cfw="collapse"])', function(event) {
-        var item = event.target;
-        var selector = item.getAttribute('href') || '';
-        if (selector.length === 0) { return; }
-        TOC_focusSelector = selector;
-        $(TOC_MODAL).CFW_Modal('hide');
-    });
-}
-
 function getReaderBody() {
     'use strict';
 
@@ -550,7 +543,6 @@ $(document).ready(function() {
 
     savePendingLocationUpdate();
     setUpNotes();
-    tocClickHandler();
 
     $(NOTES_CONTAINER)
         .on('click touchstart', '.delete-highlight', deleteAnnotation)

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -13,6 +13,8 @@ var TOC_EMPTY = '#tocEmpty';
 var NOTES_TAB = '#notesTab';  // links to #notesPanel
 var NOTES_CONTAINER = '#notesList';
 
+var TOC_focusSelector = null;
+
 // eslint-disable-next-line no-unused-vars
 function showTocPanel() {
     'use strict';
@@ -373,14 +375,9 @@ function goToAnnotation(event) {
     markAnnotationActive(json);
     d2reader.goTo(json);
 
-    // Check to see if we should close the TOC modal based on current browser breakpoint
-    var bpVal = window.getBreakpointByName('xs');
-    if (bpVal) {
-        var mediaQuery = window.matchMedia('(max-width: ' + bpVal.max + ')');
-        if (mediaQuery.matches) {
-            $(TOC_MODAL).CFW_Modal('hide');
-        }
-    }
+    // Trigger hide modal and focus on highlight
+    TOC_focusSelector = '#' + json.highlight.id;
+    $(TOC_MODAL).CFW_Modal('hide');
 }
 
 // For any changes to the 'note' of an annotation, keep display text updated and invoke auto-save.
@@ -460,18 +457,96 @@ function setUpNotes() {
     });
 }
 
-//  Initial setup
+// Accessibility addition to close TOC and move focus to selected item within the reader frame.
+// Uses click event because screen readers since they use simulated click events,
+// even if keyboard navigation is used.
+function tocClickHandler() {
+    'use strict';
 
+    $(TOC_CONTAINER).on('click', 'a:not([data-cfw="collapse"])', function(event) {
+        var item = event.target;
+        var selector = item.getAttribute('href') || '';
+        if (selector.length === 0) { return; }
+        TOC_focusSelector = selector;
+        $(TOC_MODAL).CFW_Modal('hide');
+    });
+}
+
+function getReaderBody() {
+    'use strict';
+
+    var readerIframe = document.querySelector('#D2Reader-Container iframe');
+    var readerDocument = readerIframe.contentDocument || readerIframe.contentWindow.document;
+    return readerDocument.body;
+}
+
+$(document).on('updateCurrentLocation.d2reader', function() {
+    'use strict';
+
+    if (TOC_focusSelector === null) { return; }
+
+    var _getValidSelector = function(selector, rootElement) {
+        // Split at #
+        if (selector.indexOf('#') > -1) {
+            selector = selector.substring(selector.indexOf('#'));
+        }
+
+        if (typeof rootElement === 'undefined') { rootElement = document; }
+        try {
+            return rootElement.querySelector(selector) ? selector : null;
+        } catch (error) {
+            return null;
+        }
+    };
+    var readerBody = getReaderBody();
+    var selector = _getValidSelector(TOC_focusSelector, readerBody);
+
+    setTimeout(function() {
+        if (selector === null) {
+            // No specific element - focus on body
+            setTimeout(function() {
+                readerBody.setAttribute('tabindex', -1);
+                setTimeout(function() {
+                    readerBody.focus();
+                });
+            });
+        } else if (selector.startsWith('#R2_HIGHLIGHT_')) {
+            // Focus on highlight item
+            var highlightItem = readerBody.querySelector(selector + ' .R2_CLASS_HIGHLIGHT_AREA');
+            setTimeout(function() {
+                highlightItem.focus();
+            });
+        } else {
+            // Focus on content element
+            var readerItem = readerBody.querySelector(selector);
+            setTimeout(function() {
+                readerItem.setAttribute('tabindex', -1);
+                setTimeout(function() {
+                    readerItem.focus();
+                });
+            });
+        }
+    });
+});
+
+//  Initial setup
 $(document).ready(function() {
     'use strict';
 
     savePendingLocationUpdate();
     setUpNotes();
+    tocClickHandler();
 
     $(NOTES_CONTAINER)
         .on('click touchstart', '.delete-highlight', deleteAnnotation)
         .on('click touchstart', '.goto-highlight', goToAnnotation)
         .on('click touchstart', '.link-undelete-annotation', undeleteAnnotation);
+
+    $(TOC_MODAL_BUTTON)
+        .on('click', function() {
+            TOC_focusSelector = null;
+            $(TOC_MODAL_BUTTON).CFW_Modal('show');
+        });
 
     $(TOC_MODAL)
         .on('beforeShow.cfw.modal', function() {
@@ -480,6 +555,12 @@ $(document).ready(function() {
         })
         .on('afterShow.cfw.modal', function() {
             scrollToCurrentTocItem();
+        })
+        .on('beforeHide.cfw.modal', function() {
+            if (TOC_focusSelector === null) {
+                $(TOC_MODAL_BUTTON).trigger('focus');
+                TOC_focusSelector = null;
+            }
         });
 
     $(TOC_TAB)

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -517,7 +517,6 @@ $(document).on('updateCurrentLocation.d2reader', function() {
     setTimeout(function() {
         if (selector === null) {
             // No specific element - focus on body
-
             setTimeout(function() {
                 updateTabindex(readerBody);
                 setTimeout(function() {

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -527,6 +527,8 @@ $(document).on('updateCurrentLocation.d2reader', function() {
             });
         }
     });
+
+    TOC_focusSelector = null;
 });
 
 //  Initial setup
@@ -559,7 +561,6 @@ $(document).ready(function() {
         .on('beforeHide.cfw.modal', function() {
             if (TOC_focusSelector === null) {
                 $(TOC_MODAL_BUTTON).trigger('focus');
-                TOC_focusSelector = null;
             }
         });
 

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -504,11 +504,22 @@ $(document).on('updateCurrentLocation.d2reader', function() {
     var readerBody = getReaderBody();
     var selector = _getValidSelector(TOC_focusSelector, readerBody);
 
+    var updateTabindex = function(element) {
+        var tabindex = null;
+        if (element.hasAttribute('tabindex')) {
+            tabindex = element.getAttribute('tabindex');
+        }
+        if (tabindex === null) {
+            element.setAttribute('tabindex', -1);
+        }
+    };
+
     setTimeout(function() {
         if (selector === null) {
             // No specific element - focus on body
+
             setTimeout(function() {
-                readerBody.setAttribute('tabindex', -1);
+                updateTabindex(readerBody);
                 setTimeout(function() {
                     readerBody.focus();
                 });
@@ -523,7 +534,7 @@ $(document).on('updateCurrentLocation.d2reader', function() {
             // Focus on content element
             var readerItem = readerBody.querySelector(selector);
             setTimeout(function() {
-                readerItem.setAttribute('tabindex', -1);
+                updateTabindex(readerItem);
                 setTimeout(function() {
                     readerItem.focus();
                 });

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -273,6 +273,10 @@ var simplificationTool = "{{ simplification_tool }}";
             api: {
                 resourceReady: function() {
                     console.debug("D2Reader finished loading the resource at: " + new Date());
+
+                    // Fire custom event
+                    $(document).trigger('resourceReady.d2reader');
+
                     $(document).ready(function () {
                         // Do things that only need to be done once
                         if(!firstResourceLoaded) {
@@ -311,6 +315,9 @@ var simplificationTool = "{{ simplification_tool }}";
                 //     console.debug('resourceAtStart');
                 // },
                 updateCurrentLocation: function (locator) {
+                    // Fire custom event
+                    $(document).trigger('updateCurrentLocation.d2reader');
+
                     // Grey out forward/back navigation buttons when necessary.
                     // This logic cannot be moved to resourceAtStart/resourceAtEnd since it also needs to know
                     // when you move away from the edge, so that the buttons can be re-enabled.

--- a/src/shared/templates/shared/partial/modal_toc.html
+++ b/src/shared/templates/shared/partial/modal_toc.html
@@ -23,7 +23,7 @@
                             </div>
                             {% endif %}
                             <div class="media-body">
-                                <h3 class="h5 media-title">{{ pub.title }}</h3>
+                                <h3 id="tocPubTitle" class="h5 media-title">{{ pub.title }}</h3>
                                 {{ pub.author }}
                             </div>
                         </div>

--- a/src/shared/templates/shared/partial/sidebar_start.html
+++ b/src/shared/templates/shared/partial/sidebar_start.html
@@ -1,6 +1,6 @@
 {% if nav %}
 <nav class="sidebar-region sidebar-nav" aria-label="Reading">
-    <button id="tocButton" type="button" data-cfw="modal" data-cfw-modal-target="#modalToc" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cle-handler="click" data-cle-control="contents-highlights-notes-sidebar" data-cle-value="opened">
+    <button id="tocButton" type="button" class="btn btn-nav btn-icon btn-nav-toc" aria-label="Contents, highlights, &amp; notes" title="Contents, highlights, &amp; notes" data-cfw="modal" data-cfw-modal-target="#modalToc" data-cfw-modal-manual="true" data-cle-handler="click" data-cle-control="contents-highlights-notes-sidebar" data-cle-value="opened">
         <span class="icon-th-list" aria-hidden="true"></span>
     </button>
 


### PR DESCRIPTION
Replaces #226

Note that NVDA tries to be smart when `role="dialog" items close/hide. NVDA forces focus back to the TOC button upon close of modal, even though Figuration is not doing so, but the focus does get moved properly into the reader frame.

VoiceOver focus seems to move directly into the reader frame without a brief layover on the TOC button.