### PR TITLE
CSL-1750: Add alternatives for Arial and Verdana for mobile

### DIFF
--- a/src/frontend/js/clusive-reader-prefs.js
+++ b/src/frontend/js/clusive-reader-prefs.js
@@ -12,7 +12,6 @@
     var fontFamilyArial = isAndroid ? '"Helvetica Neue", Arimo, Arial' : '"Helvetica Neue", Arial, Arimo'
     var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
 
-
     fluid.defaults('cisl.prefs.readerPreferencesBridge', {
         gradeNames: ['fluid.modelComponent'],
         model: {

--- a/src/frontend/js/clusive-reader-prefs.js
+++ b/src/frontend/js/clusive-reader-prefs.js
@@ -7,6 +7,12 @@
 (function(fluid) {
     'use strict';
 
+    var userAgent = navigator.userAgent || navigator.vendor;
+    var isAndroid = /android/i.test(userAgent);
+    var fontFamilyArial = isAndroid ? '"Helvetica Neue", Arimo, Arial' : '"Helvetica Neue", Arial, Arimo'
+    var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
+
+
     fluid.defaults('cisl.prefs.readerPreferencesBridge', {
         gradeNames: ['fluid.modelComponent'],
         model: {
@@ -45,19 +51,21 @@
                         },
                         {
                             inputValue: 'times',
-                            outputValue: 'Georgia, Times, Times New Roman, serif'
+                            outputValue: 'Georgia, Times, "Times New Roman", serif'
                         },
                         {
                             inputValue: 'arial',
-                            outputValue: 'Arial, Helvetica'
-                        }, {
+                            outputValue: fontFamilyArial
+                        },
+                        {
                             inputValue: 'verdana',
-                            outputValue: 'Verdana'
+                            outputValue: fontFamilyVerdana
                         },
                         {
                             inputValue: 'comic',
-                            outputValue: 'Comic Sans MS, Comic Sans, Comic Neue, cursive'
-                        }, {
+                            outputValue: '"Comic Sans MS", "Comic Sans", "Comic Neue", cursive'
+                        },
+                        {
                             inputValue: 'open-dyslexic',
                             outputValue: 'OpenDyslexicRegular'
                         }

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -1292,6 +1292,13 @@ function setUpDeferredLoadOfCompDetails() {
 $(window).ready(function() {
     'use strict';
 
+    // Work around Android font issue
+    var userAgent = navigator.userAgent || navigator.vendor;
+    var isAndroid = /android/i.test(userAgent);
+    if (isAndroid)  {
+        document.body.classList.add('isAndroid');
+    }
+
     document.addEventListener('update.cisl.prefs', updateCSSVars, {
         passive: true
     });

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -14,18 +14,34 @@ body {
     font-family: Georgia, Times, "Times New Roman", serif !important;
 }
 .fl-font-comic-sans:not([class*='icon']),
-.fl-font-comic-sans *:not([class*='icon']), // Override Infusion
+.fl-font-comic-sans *:not([class*='icon']),
 #ff-comic,
 .ff-comic {
     font-family: "Comic Sans MS", "Comic Sans", "Comic Neue", cursive !important;
 }
+.fl-font-arial:not([class*='icon']),
+.fl-font-arial *:not([class*='icon']),
 #ff-arial,
 .ff-arial {
-    font-family: "Helvetica Neue", Arial, sans-serif !important;
+    font-family: "Helvetica Neue", Arial, Arimo, sans-serif !important;
 }
+.isAndroid.fl-font-arial:not([class*='icon']),
+.isAndroid.fl-font-arial *:not([class*='icon']),
+.isAndroid #ff-arial,
+.isAndroid .ff-arial {
+    font-family: "Helvetica Neue", Arimo, Arial, sans-serif !important;
+}
+.fl-font-verdana:not([class*='icon']),
+.fl-font-verdana *:not([class*='icon']),
 #ff-verdana,
 .ff-verdana {
-    font-family: Verdana, sans-serif !important;
+    font-family: Verdana, Roboto, sans-serif !important;
+}
+.isAndroid.fl-font-verdana:not([class*='icon']),
+.isAndroid.fl-font-verdana *:not([class*='icon']),
+.isAndroid #ff-verdana,
+.isAndroid .ff-verdana {
+    font-family: Roboto, Verdana, sans-serif !important;
 }
 #ff-dyslexic,
 .ff-dyslexic {

--- a/src/frontend/scss/site/_dashboard.scss
+++ b/src/frontend/scss/site/_dashboard.scss
@@ -52,7 +52,7 @@
 
     th {
         @include font-size(1rem);
-        font-weight: 600;
+        font-weight: 700;
         border-bottom: 3px solid var(--CT_boxDivderColor);
 
         .active {

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -93,21 +93,26 @@ var simplificationTool = "{{ simplification_tool }}";
     </div>
 
     <script>
+        var userAgent = navigator.userAgent || navigator.vendor;
+        var isAndroid = /android/i.test(userAgent);
+        var fontFamilyArial = isAndroid ? '"Helvetica Neue", Arimo, Arial' : '"Helvetica Neue", Arial, Arimo';
+        var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
+
         var url = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port +
             '{% get_media_prefix %}' + manifest_path;
         var injectables = [
             {type: 'script', url: 'https://code.jquery.com/jquery-3.5.1.min.js'},
             {type: 'script', url: '{% static "shared/js/lib/internal.js" %}'},
-            {type: 'style', url: 'https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700', r2before: true},
+            {type: 'style', url: 'https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&family=Comic+Neue:wght@400;700&family=Roboto:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap', r2before: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-before.css" %}', r2before: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-default.css" %}', r2default: true},
             {type: 'style', url: '{% static "shared/js/lib/readium-css/ReadiumCSS-after.css" %}', r2after: true},
             {type: 'style', url: '{% static "shared/css/reader-frame.min.css" %}'},
             {type: 'style', url: '{% static "shared/js/lib/reader/fonts/open-dyslexic/open-dyslexic-regular.css" %}', fontFamily: 'OpenDyslexicRegular'},
-            {type: 'style', systemFont: true, fontFamily: 'Arial, Helvetica'},
-            {type: 'style', systemFont: true, fontFamily: 'Georgia, Times, Times New Roman, serif'},
-            {type: 'style', systemFont: true, fontFamily: 'Verdana'},
-            {type: 'style', systemFont: true, fontFamily: 'Comic Sans MS, Comic Sans, Comic Neue, cursive'},
+            {type: 'style', systemFont: true, fontFamily: fontFamilyArial},
+            {type: 'style', systemFont: true, fontFamily: 'Georgia, Times, "Times New Roman", serif'},
+            {type: 'style', systemFont: true, fontFamily: fontFamilyVerdana},
+            {type: 'style', systemFont: true, fontFamily: '"Comic Sans MS", "Comic Sans", "Comic Neue", cursive'},
             {type: 'style', url: '{% static "shared/css/clusive-reader-theme-sepia.min.css" %}', r2after: true, appearance: 'clusive-sepia'},
             {type: 'style', url: '{% static "shared/css/clusive-reader-theme-night.min.css" %}', r2after: true, appearance: 'clusive-night'},
             // {type:'script', url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_CHTML&latest'},

--- a/src/shared/templates/shared/partial/head_styles.html
+++ b/src/shared/templates/shared/partial/head_styles.html
@@ -1,7 +1,7 @@
 {% load static %}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&family=Comic+Neue:wght@400;700&family=Poppins:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
 
 <link href="{% static 'shared/font/fontello/fontello.min.css' %}" rel="stylesheet">
 <link href="{% static 'shared/js/lib/reader/fonts/open-dyslexic/open-dyslexic-regular.css' %}" rel="stylesheet">

--- a/src/shared/templates/shared/partial/head_styles.html
+++ b/src/shared/templates/shared/partial/head_styles.html
@@ -1,7 +1,7 @@
 {% load static %}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&family=Comic+Neue:wght@400;700&family=Poppins:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&family=Comic+Neue:wght@400;700&family=Roboto:wght@400;700&family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
 
 <link href="{% static 'shared/font/fontello/fontello.min.css' %}" rel="stylesheet">
 <link href="{% static 'shared/js/lib/reader/fonts/open-dyslexic/open-dyslexic-regular.css' %}" rel="stylesheet">


### PR DESCRIPTION
Yet more work arounds for mobile devices (Android and iOS) and their limited installed system fonts.
Adding some Google Font alternatives to make sure each font setting is different.

- Arial adds [Arimo](https://fonts.google.com/specimen/Arimo) alternative
- Verdana adds [Roboto](https://fonts.google.com/specimen/Roboto?query=roboto) alternative

Had to work around issue where for my phone (Nokia 6.2 - Android 11 - Chrome)  seems to have hard-coded Arial and Verdana to match up to Roboto.  (Note: Times New Roman is set to Noto Sans.)  

Work around this issue the font stack by changing the `font-family` order to place the alternative before the 'system' font.  Not doing this everywhere, just for Android, otherwise everyone would get the alternative fonts.

Also note that preferences listed in `clusive-reader-prefs.js` need to match exactly with R2D2BC's injected `systemFont`s, otherwise the font-family on the reader body results in `undefined`.

