### PR TITLE
CSL-1533 Prevent negative active time from getting recorded

### DIFF
--- a/src/frontend/js/.eslintrc.json
+++ b/src/frontend/js/.eslintrc.json
@@ -2,6 +2,7 @@
   "root": true,
   "env": {
     "browser": true,
+    "es6": true,
     "jquery": true
   },
   "extends": "eslint:recommended",
@@ -202,7 +203,10 @@
     "padded-blocks": ["error", "never"],
     "padding-line-between-statements": "off",
     "quote-props": ["error", "consistent-as-needed"],
-    "quotes": ["error", "single"],
+    "quotes": ["error", "single", {
+            "allowTemplateLiterals": true,
+            "avoidEscape": true
+    }],
     "require-jsdoc": "off",
     "semi": ["error", "always"],
     "semi-spacing": ["error", {

--- a/src/frontend/js/page-timing.js
+++ b/src/frontend/js/page-timing.js
@@ -144,12 +144,17 @@ PageTiming.reportEndTime = function() {
     if (!localStorage['pageEndTime.' + PageTiming.eventId]) {
         PageTiming.recordInactiveTime();
         var duration = Date.now() - PageTiming.pageStartTime;
+        var activeTime = duration - PageTiming.totalInactiveTime;
+        if (activeTime < 0) {
+            activeTime = 0;
+            console.log("Page tracking: reportEndTime() detected negative activeDuration");
+        }
         var data = {
             type: 'PT',
             eventId: PageTiming.eventId,
             loadTime: PageTiming.pageloadTime,
             duration: duration,
-            activeDuration: duration - PageTiming.totalInactiveTime
+            activeDuration: activeTime
         };
         console.debug('Page tracking: Reporting page data: ', data);
         clusiveEvents.messageQueue.add(data);
@@ -163,7 +168,7 @@ PageTiming.reportEndTime = function() {
     }
 };
 
-// If browser supports both of the the PerformanceObserver and the
+// If browser supports both of the PerformanceObserver and the
 // PerformanceNavigationTiming APIs, set up a PerformanceObserver to observe the
 // navigation events to get the page's load time.
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver

--- a/src/frontend/js/page-timing.js
+++ b/src/frontend/js/page-timing.js
@@ -46,7 +46,7 @@ PageTiming.trackPage = function(eventId) {
         // it to acquire the page load time.
         if ('performance' in window && 'timing' in window.performance) {
             PageTiming.pageloadTime = window.performance.timing.responseEnd - window.performance.timing.navigationStart;
-            console.log("PageTiming: LOAD TIME VIA Performance.timing: " + PageTiming.pageloadTime);
+            console.debug('PageTiming: LOAD TIME VIA Performance.timing: ' + PageTiming.pageloadTime);
         }
     }
     var currentTime = Date.now();
@@ -140,6 +140,7 @@ PageTiming.recordInactiveTime = function() {
 // Called in page's "pagehide" event
 PageTiming.reportEndTime = function() {
     'use strict';
+
     console.debug(`PageTiming: reportEndTime() for ${PageTiming.eventId}, load time is ${PageTiming.pageloadTime}`);
     if (!localStorage['pageEndTime.' + PageTiming.eventId]) {
         PageTiming.recordInactiveTime();
@@ -154,7 +155,7 @@ PageTiming.reportEndTime = function() {
             eventId: PageTiming.eventId,
             loadTime: PageTiming.pageloadTime,
             duration: duration,
-            activeDuration: activeTime,
+            activeDuration: activeTime
         };
         console.debug('PageTiming: Reporting page data: ', data);
         clusiveEvents.messageQueue.add(data);
@@ -173,31 +174,35 @@ PageTiming.reportEndTime = function() {
 // navigation events to get the page's load time.
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
-PageTiming.usePerformanceObserver = function () {
+PageTiming.usePerformanceObserver = function() {
+    'use strict';
+
     var observer = null;
     if (window.PerformanceObserver && window.PerformanceNavigationTiming) {
-        observer = new PerformanceObserver(function (perfEntries) {
+        observer = new PerformanceObserver(function(perfEntries) {
             PageTiming.processNavEntries(perfEntries);
         });
-        observer.observe({ type: "navigation", buffered: true });
-    };
+        observer.observe({
+            type: 'navigation',
+            buffered: true
+        });
+    }
     return observer;
 };
 
 // Called from the PerformanceObserver callback to get the page load time.
 // See PageTiming.usePerformanceObserver(), above.
-PageTiming.processNavEntries = function (perfEntries) {
+PageTiming.processNavEntries = function(perfEntries) {
     'use strict';
 
     var navEntries = perfEntries.getEntries();
-    navEntries.some(function (entry) {
+    navEntries.some(function(entry) {
         if (entry.name === document.URL) {  // TODO: is check needed?
             PageTiming.pageloadTime = entry.duration;
-            console.log(`PageTiming: LOAD TIME VIA PerformanceNavigationTiming for ${PageTiming.eventId}: ${PageTiming.pageloadTime}`);
+            console.debug(`PageTiming: LOAD TIME VIA PerformanceNavigationTiming for ${PageTiming.eventId}: ${PageTiming.pageloadTime}`);
             return true;
-        } else {
-            return false;
         }
+        return false;
     });
 };
 

--- a/src/frontend/js/page-timing.js
+++ b/src/frontend/js/page-timing.js
@@ -23,6 +23,7 @@ PageTiming.pageBlocked = false;
 PageTiming.lastSeenAwakeTime = null;
 PageTiming.awakeCheckInterval = 5000;  // Check for awakeness every 5 seconds
 PageTiming.awakeCheckTimer = null;
+PageTiming.performanceObserver = null;
 
 /**
  * Call to initiate time tracking of this page.
@@ -34,8 +35,20 @@ PageTiming.trackPage = function(eventId) {
 
     PageTiming.eventId = eventId;
 
-    console.debug('Started tracking page ', eventId);
+    console.debug('Page tracking: Started tracking page ', eventId);
 
+    // First choice:  Use PerformanceObserver and PerformanceNavigationTiming
+    // APIs if available -- check is made in usePerformanceObserver() and
+    // observer is returned if check succeeds.
+    PageTiming.performanceObserver = PageTiming.usePerformanceObserver();
+    if (!PageTiming.performanceObserver) {
+        // Second choice: if deprecated Performance.timing is available, use
+        // it to acquire the page load time.
+        if ('performance' in window && 'timing' in window.performance) {
+            PageTiming.pageloadTime = window.performance.timing.responseEnd - window.performance.timing.navigationStart;
+            console.log("Page tracking: LOAD TIME VIA Performance.timing: " + PageTiming.pageloadTime);
+        }
+    }
     var currentTime = Date.now();
     var timingSupported = PageTiming.isTimingSupported();
 
@@ -44,15 +57,11 @@ PageTiming.trackPage = function(eventId) {
         PageTiming.handleFocusChange();
         $(window).on('focusin focusout', PageTiming.handleFocusChange);
     } else {
-        console.warn('Browser doesn\'t support focus checking; hidden time won\'t be reported.');
+        console.warn('Page tracking: Browser doesn\'t support focus checking; hidden time won\'t be reported.');
     }
 
     // Interval timer to monitor laptop going to sleep.
     PageTiming.awakeCheckTimer = setInterval(PageTiming.checkAwakeness, PageTiming.awakeCheckInterval);
-
-    if (timingSupported) {
-        PageTiming.pageloadTime = performance.timing.responseEnd - performance.timing.navigationStart;
-    }
 
     // Set up so that end time will be recorded
     $(window).on('pagehide', function() { PageTiming.reportEndTime(); });
@@ -73,13 +82,13 @@ PageTiming.checkAwakeness = function() {
         //     ' blocked? ', PageTiming.pageBlocked, '; blurred? ', !document.hasFocus());
     } else {
         // Last awake time was too long ago, record preceding interval as having been asleep.
-        console.debug('Computer woke up from sleep that started around ' + PageTiming.fmt(lastAwake));
+        console.debug('Page tracking: Computer woke up from sleep that started around ' + PageTiming.fmt(lastAwake));
         if (PageTiming.startInactiveTime === null) {
             //   do we need this?:  || PageTiming.startInactiveTime > lastAwake
             PageTiming.startInactiveTime = lastAwake; // might want to add a fraction of interval
-            console.debug('Set startInactiveTime to ', PageTiming.fmt(lastAwake));
+            console.debug('Page tracking: Set startInactiveTime to ', PageTiming.fmt(lastAwake));
         } else {
-            console.debug('startInactiveTime is already set to ', PageTiming.fmt(PageTiming.startInactiveTime),
+            console.debug('Page tracking: startInactiveTime is already set to ', PageTiming.fmt(PageTiming.startInactiveTime),
                 ' so not resetting to ', PageTiming.fmt(lastAwake));
         }
         PageTiming.handleFocusChange();
@@ -102,7 +111,7 @@ PageTiming.handleFocusChange = function() {
     } else if (PageTiming.startInactiveTime === null) {
         // Page is either blocked or blurred.  Record start of inactive time if this is new.
         PageTiming.startInactiveTime = Date.now();
-        console.debug('Window went inactive at ', PageTiming.fmt(PageTiming.startInactiveTime),
+        console.debug('Page tracking: Window went inactive at ', PageTiming.fmt(PageTiming.startInactiveTime),
             ' with cumulative ', PageTiming.totalInactiveTime / 1000, 's');
     }
 };
@@ -122,7 +131,7 @@ PageTiming.recordInactiveTime = function() {
     if (PageTiming.startInactiveTime !== null) {
         var now = Date.now();
         PageTiming.totalInactiveTime += now - PageTiming.startInactiveTime;
-        console.debug('Window reactivated. Was inactive from ', PageTiming.fmt(PageTiming.startInactiveTime),
+        console.debug('Page tracking: Window reactivated. Was inactive from ', PageTiming.fmt(PageTiming.startInactiveTime),
             ' to ', PageTiming.fmt(now),
             '; Cumulative inactive time = ', PageTiming.totalInactiveTime / 1000, 's');
         PageTiming.startInactiveTime = null;
@@ -132,9 +141,13 @@ PageTiming.recordInactiveTime = function() {
 // Called in page's "pagehide" event
 PageTiming.reportEndTime = function() {
     'use strict';
-
+    console.log(`Page tracking: reportEndTime(start) for ${PageTiming.eventId}, load time is ${PageTiming.pageloadTime}`);
+    if (PageTiming.pageloadTime === null) {
+        PageTiming.pageloadTime = PageTiming.getPageLoadTime();
+    };
     if (!localStorage['pageEndTime.' + PageTiming.eventId]) {
         PageTiming.recordInactiveTime();
+        console.log(`Page tracking: reportEndTime(record event) for ${PageTiming.eventId}, load time is ${PageTiming.pageloadTime}`);
         var duration = Date.now() - PageTiming.pageStartTime;
         var data = {
             type: 'PT',
@@ -143,23 +156,101 @@ PageTiming.reportEndTime = function() {
             duration: duration,
             activeDuration: duration - PageTiming.totalInactiveTime
         };
-        console.debug('Reporting page data: ', data);
+        console.debug('Page tracking: Reporting page data: ', data);
         clusiveEvents.messageQueue.add(data);
     } else {
-        console.warn('Pagehide event received, but end time was already recorded');
+        console.warn('Page tracking: Pagehide event received, but end time was already recorded');
     }
 };
 
-// Test if browser supports the timing API
+// Test if browser supports a timing API
 PageTiming.isTimingSupported = function() {
     'use strict';
 
+    // First choice:  dheck for recommended PageNavigationTiming API.
+    // Note: as of 04-May-2022, MDN notes that this is experimental -- use if
+    // present.  See:
+    // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
     try {
-        return 'performance' in window && 'timing' in window.performance;
-    } catch (e) {
+        return window.performance.getEntriesByType('navigation').length !== 0;
+    }
+    catch (e) { ; }
+
+    // Second choice:  Check for deprecated Performance.timing and use if
+    // available.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Performance/timing
+    try {
+        return 'timing' in window.performance;
+    }
+    catch (e) {
         return false;
     }
 };
+
+// If browser supports both of the the PerformanceObserver and the
+// PerformanceNavigationTiming APIs, set up a PerformanceObserver to observe the
+// navigation events to get the page's load time.
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+PageTiming.usePerformanceObserver = function () {
+    var observer = null;
+    if (window.PerformanceObserver && window.PerformanceNavigationTiming) {
+        observer = new PerformanceObserver(function (perfEntries) {
+            PageTiming.processNavEntries(perfEntries);
+        });
+        observer.observe({ type: "navigation", buffered: true });
+    };
+    return observer;
+};
+
+// Called from the PerformanceObserver callback to get the page load time.
+PageTiming.processNavEntries = function (perfEntries) {
+    'use strict';
+
+    var navEntries = perfEntries.getEntries();
+    navEntries.some(function (entry) {
+        if (entry.name === document.URL) {  // TODO: is check needed?
+            PageTiming.pageloadTime = entry.duration;
+            console.log(`Page tracking: LOAD TIME VIA PerformanceNavigationTiming for ${PageTiming.eventId}: ${PageTiming.pageloadTime}`);
+            return true;
+        } else {
+            return false;
+        }
+    });
+};
+
+// If browser supports either the PerformanceNavigationTiming API or
+// Performance.timing, get the load time for it.  Otherwise, return `null`.
+PageTiming.getPageLoadTime = function () {
+    'use strict';
+
+    var loadTime = null;
+    if ('performance' in window) {
+        // First choice:  use recommended PageNavigationTiming API.
+        // Note: as of 04-May-2022, MDN notes that this is experimental -- use
+        // if present.  See:
+        // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+        var navEntries = window.performance.getEntriesByName('navigation');
+        navEntries.some(function (entry) {
+            if (entry.name === document.URL) {  // TODO: is check needed?
+                loadTime = entry.duration;
+                console.log("Page tracking: getPageLoadTimeI() via PerformanceNavigationTiming: <loadTime>" + loadTime);
+                return true;
+            } else {
+                return false;
+            }
+        });
+        // Second choice:  Check for deprecated Performance.timing and use if
+        // available.
+        // https://developer.mozilla.org/en-US/docs/Web/API/Performance/timing
+        if (loadTime === null && 'timing' in window.performance) {
+            loadTime = window.performance.timing.responseEnd - window.performance.timing.navigationStart;
+            console.log("Page tracking: getPageLoadTimeI() via Performance.timing: " + loadTime);
+        }
+    }
+    return loadTime;
+};
+
 
 $(document).ready(function() {
     'use strict';


### PR DESCRIPTION
- "Handle" negative `active_duration` in PageTiming by setting it to zero. 
- Detect and use `PerformanceNavigationTiming` API for getting load times if available.

JIRA: https://castudl.atlassian.net/browse/CSL-1553