### PR TITLE
CSL-1872: Improve load times

### DIFF
--- a/src/library/models.py
+++ b/src/library/models.py
@@ -204,6 +204,16 @@ class BookVersion(models.Model):
         return '%s/manifest.json' % (self.path)
 
     @property
+    def positions_path(self):
+        """Relative, URL-style path from MEDIA_URL to the manifest for this book version."""
+        return '%s/positions.json' % (self.path)
+
+    @property
+    def weight_path(self):
+        """Relative, URL-style path from MEDIA_URL to the manifest for this book version."""
+        return '%s/weight.json' % (self.path)
+
+    @property
     def storage_dir(self):
         """Absolute filesystem location of this book version's content."""
         return os.path.join(self.book.storage_dir, str(self.sortOrder))

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -205,12 +205,12 @@ class BookVersion(models.Model):
 
     @property
     def positions_path(self):
-        """Relative, URL-style path from MEDIA_URL to the manifest for this book version."""
+        """Relative, URL-style path from MEDIA_URL to the positions for this book version."""
         return '%s/positions.json' % (self.path)
 
     @property
     def weight_path(self):
-        """Relative, URL-style path from MEDIA_URL to the manifest for this book version."""
+        """Relative, URL-style path from MEDIA_URL to the weights for this book version."""
         return '%s/weight.json' % (self.path)
 
     @property

--- a/src/library/parsing.py
+++ b/src/library/parsing.py
@@ -216,11 +216,6 @@ def unpack_epub_file(clusive_user, file, book=None, sort_order=0, omit_filename=
         return book_version, True
 
 
-def save_json_files(dir, file_names, dicts):
-    for file_name in file_names:
-        with open(os.path.join(dir, file_name), 'w') as json_file:
-            json_file.write(json.dumps())
-
 def get_metadata_item(book, name):
     item = book.meta.get(name)
     if item:

--- a/src/library/parsing.py
+++ b/src/library/parsing.py
@@ -357,7 +357,7 @@ def make_positions_and_weight(epub: Epub, zip_file: ZipFile, manifest: dict):
                 positions.append(locator)
             start_position += position_count
         except KeyError:
-            logger.debug('No entry in %s for %s', zip_file.filename, link['href'])
+            logger.debug('No entry in %s for %s, ignoring', zip_file.filename, link['href'])
 
     # Loop through the reading order again, using the just calculated `positions`
     # to calculate the weight of each linked item

--- a/src/library/parsing.py
+++ b/src/library/parsing.py
@@ -345,7 +345,7 @@ def make_positions_and_weight(epub: Epub, zip_file: ZipFile, manifest: dict):
     for link in manifest['readingOrder']:
         try:
             zip_entry = zip_file.getinfo(link['href'])
-            entry_length = zip_entry.compress_size
+            entry_length = zip_entry.file_size
             link['contentLength'] = entry_length
             total_content_length += entry_length
             position_count = max(1, math.ceil(entry_length / POSITION_LENGTH))

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -101,8 +101,8 @@ var simplificationTool = "{{ simplification_tool }}";
         var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
         var baseMediaUrl = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '{% get_media_prefix %}'
         var url = baseMediaUrl + manifest_path;
-        var positionsUrl = baseMediaUrl + positions_path;
-        var weightUrl = baseMediaUrl + weight_path;
+        var positionsUrl = ( positions_path ? baseMediaUrl + positions_path : null );
+        var weightUrl = ( weight_path ? baseMediaUrl + weight_path : null );
         var injectables = [
             {type: 'script', url: 'https://code.jquery.com/jquery-3.5.1.min.js'},
             {type: 'script', url: '{% static "shared/js/lib/internal.js" %}'},
@@ -144,8 +144,6 @@ var simplificationTool = "{{ simplification_tool }}";
 
         var readerOptions = {
             url: new URL(url),
-            positionsUrl: new URL(positionsUrl),
-            weightUrl: new URL(weightUrl),
             userSettings: {
                 textAlignment:'start',
                 columnCount: '1'
@@ -160,7 +158,7 @@ var simplificationTool = "{{ simplification_tool }}";
                 enableAnnotations: true,
                 enableDefinitions: true,
                 enableTTS: true,
-                autoGeneratePositions: true,
+                autoGeneratePositions: !positions_path,
                 enableLineFocus: true,
                 enableBookmarks: false,
                 enableMaterial: false,
@@ -353,6 +351,12 @@ var simplificationTool = "{{ simplification_tool }}";
                 }
             }
         };
+        if (positions_path) {
+            readerOptions.services = {
+                positions: { href: new URL(positionsUrl) },
+                weight: { href: new URL(weightUrl) }
+            }
+        }
 
         // Wait for the reader preferences bridge to be created, then create the Reader
         document.addEventListener("cisl.prefs.readerPreferencesBridge.onCreate", function (e) {

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -8,6 +8,8 @@ var pub_id = "{{ pub.id }}";
 var pub_version = "{{ version }}";
 var pub_version_id = "{{ version_id }}";
 var manifest_path = "{{ manifest_path }}";
+var positions_path = "{{ positions_path }}";
+var weight_path = "{{ weight_path }}";
 // FIXME eventually this will be a per-user default
 var simplificationTool = "{{ simplification_tool }}";
 </script>
@@ -97,9 +99,10 @@ var simplificationTool = "{{ simplification_tool }}";
         var isAndroid = /android/i.test(userAgent);
         var fontFamilyArial = isAndroid ? '"Helvetica Neue", Arimo, Arial' : '"Helvetica Neue", Arial, Arimo';
         var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
-
-        var url = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port +
-            '{% get_media_prefix %}' + manifest_path;
+        var baseMediaUrl = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '{% get_media_prefix %}'
+        var url = baseMediaUrl + manifest_path;
+        var positionsUrl = baseMediaUrl + positions_path;
+        var weightUrl = baseMediaUrl + weight_path;
         var injectables = [
             {type: 'script', url: 'https://code.jquery.com/jquery-3.5.1.min.js'},
             {type: 'script', url: '{% static "shared/js/lib/internal.js" %}'},
@@ -141,6 +144,8 @@ var simplificationTool = "{{ simplification_tool }}";
 
         var readerOptions = {
             url: new URL(url),
+            positionsUrl: new URL(positionsUrl),
+            weightUrl: new URL(weightUrl),
             userSettings: {
                 textAlignment:'start',
                 columnCount: '1'

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -158,7 +158,7 @@ var simplificationTool = "{{ simplification_tool }}";
                 enableAnnotations: true,
                 enableDefinitions: true,
                 enableTTS: true,
-                autoGeneratePositions: !positions_path,
+                autoGeneratePositions: !positionsUrl,
                 enableLineFocus: true,
                 enableBookmarks: false,
                 enableMaterial: false,

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -101,8 +101,8 @@ var simplificationTool = "{{ simplification_tool }}";
         var fontFamilyVerdana = isAndroid ? 'Roboto, Verdana' : 'Verdana, Roboto';
         var baseMediaUrl = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '{% get_media_prefix %}'
         var url = baseMediaUrl + manifest_path;
-        var positionsUrl = ( positions_path ? baseMediaUrl + positions_path : null );
-        var weightUrl = ( weight_path ? baseMediaUrl + weight_path : null );
+        var positionsUrl = ( positions_path === 'False' ? null : baseMediaUrl + positions_path );
+        var weightUrl = ( weight_path === 'False' ? null : baseMediaUrl + weight_path );
         var injectables = [
             {type: 'script', url: 'https://code.jquery.com/jquery-3.5.1.min.js'},
             {type: 'script', url: '{% static "shared/js/lib/internal.js" %}'},
@@ -351,7 +351,7 @@ var simplificationTool = "{{ simplification_tool }}";
                 }
             }
         };
-        if (positions_path) {
+        if (positionsUrl) {
             readerOptions.services = {
                 positions: { href: new URL(positionsUrl) },
                 weight: { href: new URL(weightUrl) }

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -559,6 +559,8 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             'version_id': self.book_version.id,
             'version_count': len(versions),
             'manifest_path': self.book_version.manifest_path,
+            'positions_path': self.book_version.positions_path,
+            'weight_path': self.book_version.weight_path,
             'last_position': pdata.last_location or "null",
             'annotations': annotationList,
             'cuelist': json.dumps(cuelist),

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import date, timedelta
+from os.path import exists
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
@@ -554,13 +555,21 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             if clusive_user.current_period else None
         logger.debug('Customization: %s', customizations)
 
+        if exists(self.book_version.storage_dir + '/positions.json'):
+            positions_path = self.book_version.positions_path
+            weight_path = self.book_version.weight_path
+            logger.debug('Positions: %s, Weight: %s', positions_path, weight_path)
+        else:
+            positions_path = weight_path = False
+            logger.debug('No pre-calculated positions or weight')
+
         self.extra_context = {
             'pub': book,
             'version_id': self.book_version.id,
             'version_count': len(versions),
             'manifest_path': self.book_version.manifest_path,
-            'positions_path': self.book_version.positions_path,
-            'weight_path': self.book_version.weight_path,
+            'positions_path': positions_path,
+            'weight_path': weight_path,
             'last_position': pdata.last_location or "null",
             'annotations': annotationList,
             'cuelist': json.dumps(cuelist),


### PR DESCRIPTION
This adds a `make_positions_and_weight()` function that is used during book import that adds content length to the reading order items in Clusive's `manifest.json`, and generates the `positions.json` and `weight.json` files.

A problem was found with two of the epubs from Clusive's public content.  One was the `tocqueville_democracy-vol1.pub`, in the `gutenberg-tocqueville-democracy-vol1` folder.  The other was volume two.  Volume one's meta-data, and consequently the manifest's reading order, include a link to `../_public_vhost_g_gutenberg_html_files_815_815-h_815-h-19_appendix.xhtml`.  But there is no such entry in the zipfile.

In that case, the `contentLength` for the reading order item in the manifest is left out, and no position nor weight is calculated for it.  I'm not sure if that is the correct thing to do.  The alternative is set its `contentLength` to zero, and put something in for the position and weight (a zero weight?)

Also, `make_positions_and_weight()` does not test for the `publication.metadata.rendition.layout == 'fixed'` condition.  Still to come...

JIRA: https://castudl.atlassian.net/browse/CSL-1872