### PR TITLE
CSL-1814: `aria-live` tweaks, new 'Where am i?', simple notification, toc active fixes

### DIFF
--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -498,7 +498,7 @@ function showTooltip(name) {
                 if (tip_control.is(':visible')) {
                     tip_popover.attr({
                         'role': 'status',
-                        'aria-live': 'assertive',
+                        'aria-live': 'polite',
                         'aria-atomic': 'true'
                     });
                     tip_control.CFW_Tooltip('show');

--- a/src/frontend/js/notify.js
+++ b/src/frontend/js/notify.js
@@ -1,0 +1,44 @@
+/* global notify */
+
+// Super simple notification
+(function($) {
+    'use strict';
+
+    var SELECTOR_CONTAINER = '#notifyContainer';
+
+    var CLASS_FADE = 'fade';
+    var CLASS_IN = 'in';
+
+    var notifyModule = function() {
+    };
+
+    notifyModule.prototype = {
+        show : function(msg) {
+            var $item = $('<div class="notify" aria-live="assertive" aria-atomic="true"></div>');
+            $item.html(msg);
+            $(SELECTOR_CONTAINER).append($item);
+
+            var complete = function() {
+                setTimeout(function() {
+                    notify.hide($item);
+                }, 3000);
+            };
+
+            $item.addClass(CLASS_FADE);
+            $.CFW_reflow($item); // Reflow for transition
+            $item.addClass(CLASS_IN);
+            $item.CFW_transition(null, complete);
+        },
+
+        hide : function($item) {
+            var complete = function() {
+                $item.remove();
+            }
+
+            $item.removeClass(CLASS_IN);
+            $item.CFW_transition(null, complete);
+        }
+    }
+
+    window.notify = notifyModule.prototype;
+}(jQuery));

--- a/src/frontend/js/notify.js
+++ b/src/frontend/js/notify.js
@@ -10,6 +10,7 @@
     var CLASS_IN = 'in';
 
     var notifyModule = function() {
+        // placeholder
     };
 
     notifyModule.prototype = {
@@ -33,12 +34,12 @@
         hide : function($item) {
             var complete = function() {
                 $item.remove();
-            }
+            };
 
             $item.removeClass(CLASS_IN);
             $item.CFW_transition(null, complete);
         }
-    }
+    };
 
     window.notify = notifyModule.prototype;
 }(jQuery));

--- a/src/frontend/js/shortcut.js
+++ b/src/frontend/js/shortcut.js
@@ -1,4 +1,4 @@
-/* global clusiveTTS, contextLookup, contextTransform, d2reader, hotkeys, shortcut */
+/* global clusiveTTS, contextLookup, contextTransform, d2reader, getTocTitle, hotkeys, notify, shortcut */
 
 // Uses `hotkeys-js`
 // Repo: https://github.com/jaywcjlove/hotkeys
@@ -384,19 +384,20 @@
             var title = null;
             var percent = null;
             var msg = '';
+
+            if (event) { event.preventDefault(); }
+            shortcut.addEvent('hotkey-whereami', keys);
+
             if (shortcut.readerFound) {
                 // Give location within reader document
                 title = getTocTitle();
                 percent = Math.round(parseFloat(d2reader.currentLocator.locations.totalProgression) * 100);
-            } else {
-                title = document.title.replace(' | Clusive', '');
-            }
-
-            if (percent) {
                 msg = 'You are ' + percent + '% through ' + title;
             } else {
-                msg = 'You are on Clusive\'s ' + title + ' page'
+                title = document.title.replace(' | Clusive', '');
+                msg = 'You are on Clusive\'s ' + title + ' page';
             }
+
             notify.show(msg);
         }
     };

--- a/src/frontend/js/shortcut.js
+++ b/src/frontend/js/shortcut.js
@@ -1,4 +1,4 @@
-/* global clusiveTTS, contextLookup, contextTransform, d2reader, getTocTitle, hotkeys, notify, shortcut */
+/* global clusiveTTS, contextLookup, contextTransform, d2reader, getCurrentTocEntryTitle, getTocTitle, hotkeys, notify, shortcut */
 
 // Uses `hotkeys-js`
 // Repo: https://github.com/jaywcjlove/hotkeys
@@ -381,8 +381,9 @@
 
         // 'Where am I?'
         whereAmI: function(event, keys) {
-            var title = null;
-            var percent = null;
+            var title = '';
+            var section = '';
+            var percent = '';
             var msg = '';
 
             if (event) { event.preventDefault(); }
@@ -391,8 +392,10 @@
             if (shortcut.readerFound) {
                 // Give location within reader document
                 title = getTocTitle();
+                section = getCurrentTocEntryTitle(true);
+                section = section === '' ? 'Unknown' : section;
                 percent = Math.round(parseFloat(d2reader.currentLocator.locations.totalProgression) * 100);
-                msg = 'You are ' + percent + '% through ' + title;
+                msg = 'You are ' + percent + '% through ' + title + '; section ' + section;
             } else {
                 title = document.title.replace(' | Clusive', '');
                 msg = 'You are on Clusive\'s ' + title + ' page';

--- a/src/frontend/js/shortcut.js
+++ b/src/frontend/js/shortcut.js
@@ -89,6 +89,11 @@
             keys: 'alt+s',
             routine: 'contextTransform',
             blocker: 'contextTransformBlocker'
+        },
+        {
+            keys: 'alt+w',
+            routine: 'whereAmI',
+            blocker: true
         }
     ];
 
@@ -372,6 +377,27 @@
                     document.querySelector(SELECTOR_SIMPLIFY_DIALOG).focus();
                 }
             }
+        },
+
+        // 'Where am I?'
+        whereAmI: function(event, keys) {
+            var title = null;
+            var percent = null;
+            var msg = '';
+            if (shortcut.readerFound) {
+                // Give location within reader document
+                title = getTocTitle();
+                percent = Math.round(parseFloat(d2reader.currentLocator.locations.totalProgression) * 100);
+            } else {
+                title = document.title.replace(' | Clusive', '');
+            }
+
+            if (percent) {
+                msg = 'You are ' + percent + '% through ' + title;
+            } else {
+                msg = 'You are on Clusive\'s ' + title + ' page'
+            }
+            notify.show(msg);
         }
     };
 

--- a/src/frontend/js/stt.js
+++ b/src/frontend/js/stt.js
@@ -358,8 +358,7 @@
 
         // Watch for 'hide' events
         // check STT target visibility to see if recognition needs to be stopped.
-        $(document).on('afterHide.cfw.modal afterHide.cfw.popover', function(e) {
-            var $node = $(e.target);
+        $(document).on('afterHide.cfw.modal afterHide.cfw.popover', function() {
             $('[data-cast="stt"]').each(function() {
                 var $stt = $(this);
                 if ($stt.data('cast.stt').recognizing && $stt.data('cast.stt').$target.is(':hidden')) {

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -136,7 +136,18 @@ function attemptFindCurrentHash(current) {
             }
         });
     } else {
-console.log('TODO: (TOC) PAGED MODE NOT HANDLED YET');
+        var pageWidth = iframeWrapper.getBoundingClientRect().width;
+
+        hashes.forEach(function(hash) {
+            var node = readerBody.querySelector(hash);
+            if (node) {
+                var nodeOffset = node.getBoundingClientRect().left;
+                if(nodeOffset < pageWidth) {
+                    // Should be visible on page
+                    lastPassedHash = hash;
+                }
+            }
+        });
     }
 
     return lastPassedHash;

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -1,6 +1,7 @@
 /* global d2reader, DJANGO_CSRF_TOKEN, PAGE_EVENT_ID, clusiveAutosave */
 /* exported buildTableOfContents, trackReadingLocation,
-   buildAnnotationList, addNewAnnotation, showExistingAnnotation */
+   buildAnnotationList, addNewAnnotation, showExistingAnnotation,
+   getCurrentTocEntryTitle */
 
 // Some IDs are required to be used in the side modal:
 var TOC_MODAL_BUTTON = '#tocButton';
@@ -163,8 +164,8 @@ function attemptFindCurrentHash(current) {
     return lastPassedHash;
 }
 
-// Called when TOC modal is opened - activates the current location
-function markTocItemActive() {
+// Return jQuery element for current TOC location
+function getCurrentTocElement() {
     'use strict';
 
     var current = d2reader.mostRecentNavigatedTocItem;
@@ -172,31 +173,40 @@ function markTocItemActive() {
         current = current.substr(1);
     }
 
-    var top = $(TOC_CONTAINER);
-    var elt = [];
+    var $top = $(TOC_CONTAINER);
+    var $elt = [];
     var currentHash = attemptFindCurrentHash(current);
 
     if (currentHash) {
-        elt = top.find('a[href*=\'' + current + currentHash + '\']');
+        $elt = $top.find('a[href*=\'' + current + currentHash + '\']');
     }
 
-    if (elt.length === 0) {
-        elt = top.find('a[href$=\'' + current + '\']');
+    if ($elt.length === 0) {
+        $elt = $top.find('a[href$=\'' + current + '\']');
     }
 
-    if (elt.length === 0) {
-        elt = top.find('a[href*=\'' + current + '\']');
+    if ($elt.length === 0) {
+        $elt = $top.find('a[href*=\'' + current + '\']');
     }
 
     // Use only first matching item if mutliple matching TOC entries
-    elt = elt.eq(0);
+    $elt = $elt.eq(0);
+
+    return $elt;
+}
+
+// Called when TOC modal is opened - activates the current location
+function markTocItemActive() {
+    'use strict';
+
+    var $elt = getCurrentTocElement();
 
     // Add active class to current element and any related 'parent' sections
-    elt.addClass('active').attr('aria-current', true);
-    elt.parents('li').children('.nav-link').addClass('active');
+    $elt.addClass('active').attr('aria-current', true);
+    $elt.parents('li').children('.nav-link').addClass('active');
 
     // Open collapsers to show the current section
-    elt.parents('li').children('a[data-cfw="collapse"]').attr('aria-current', true).CFW_Collapse('show');
+    $elt.parents('li').children('a[data-cfw="collapse"]').attr('aria-current', true).CFW_Collapse('show');
 }
 
 // Scroll the TOC display so that the active item can be seen.
@@ -229,6 +239,34 @@ function getTocItems() {
         }];
     }
     return items;
+}
+
+// Get the current TOC entry title
+// Return a entry name as text string that includes ancestor entries
+// Don't rely on active markers from TOC as they may not be current
+function getCurrentTocEntryTitle(doNested) {
+    'use strict';
+
+    doNested = typeof doNested === 'undefined' ? false : doNested;
+
+    var output = '';
+    var $elt = getCurrentTocElement();
+
+    // Add active class to current element and any related 'parent' sections
+    if ($elt.length) {
+        output += $elt[0].innerHTML;
+    }
+
+    if (doNested) {
+        var $ancestors = $elt.parents('li').children('.nav-link');
+        $ancestors.each(function() {
+            if (this !== $elt[0]) {
+                output = this.innerHTML + ', ' + output;
+            }
+        });
+    }
+
+    return output;
 }
 
 // Creates TOC contents for the current book.

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -101,6 +101,47 @@ function resetCurrentTocItem(collapse) {
     }
 }
 
+function attemptFindCurrentHash(current) {
+    var top = $(TOC_CONTAINER);
+    var $elt = top.find('a[href*=\'' + current + '\']');
+    var hashes = [];
+    var isScrollMode = d2reader.currentSettings.verticalScroll;
+    var readerBody = getReaderBody();
+    var iframeWrapper = document.querySelector('#iframe-wrapper')
+    var lastPassedHash = null;
+
+    $elt.each(function() {
+        var href = $(this).attr('href');
+        var url = new URL(href, 'http://localhost');
+        if (url.hash !== '') {
+            hashes.push(url.hash);
+        }
+    });
+
+    if (!hashes.length) {
+        return null;
+    }
+
+    if (isScrollMode) {
+        var scrollTop = iframeWrapper.scrollTop;
+        var pageMid = iframeWrapper.getBoundingClientRect().height / 2;
+
+        hashes.forEach(function(hash) {
+            var node = readerBody.querySelector(hash);
+            if (node) {
+                if (node.offsetTop < scrollTop + pageMid) {
+                    // Passed the page midpoint
+                    lastPassedHash = hash;
+                }
+            }
+        });
+    } else {
+console.log('TODO: (TOC) PAGED MODE NOT HANDLED YET');
+    }
+
+    return lastPassedHash;
+}
+
 // Called when TOC modal is opened - activates the current location
 function markTocItemActive() {
     'use strict';

--- a/src/frontend/js/toc.js
+++ b/src/frontend/js/toc.js
@@ -34,6 +34,14 @@ function showNotesPanel() {
  * Functions dealing with location tracking and the Table of Contents modal.
  */
 
+function getReaderBody() {
+    'use strict';
+
+    var readerIframe = document.querySelector('#D2Reader-Container iframe');
+    var readerDocument = readerIframe.contentDocument || readerIframe.contentWindow.document;
+    return readerDocument.body;
+}
+
 // Create HTML for a single level of TOC structure
 function buildTocLevel(list, level, id) {
     'use strict';
@@ -102,17 +110,19 @@ function resetCurrentTocItem(collapse) {
 }
 
 function attemptFindCurrentHash(current) {
+    'use strict';
+
     var top = $(TOC_CONTAINER);
     var $elt = top.find('a[href*=\'' + current + '\']');
     var hashes = [];
     var isScrollMode = d2reader.currentSettings.verticalScroll;
     var readerBody = getReaderBody();
-    var iframeWrapper = document.querySelector('#iframe-wrapper')
+    var iframeWrapper = document.querySelector('#iframe-wrapper');
     var lastPassedHash = null;
 
     $elt.each(function() {
         var href = $(this).attr('href');
-        var url = new URL(href, 'http://localhost');
+        var url = new URL(href, 'http://localhost'); // eslint-disable-line compat/compat
         if (url.hash !== '') {
             hashes.push(url.hash);
         }
@@ -142,7 +152,7 @@ function attemptFindCurrentHash(current) {
             var node = readerBody.querySelector(hash);
             if (node) {
                 var nodeOffset = node.getBoundingClientRect().left;
-                if(nodeOffset < pageWidth) {
+                if (nodeOffset < pageWidth) {
                     // Should be visible on page
                     lastPassedHash = hash;
                 }
@@ -163,7 +173,16 @@ function markTocItemActive() {
     }
 
     var top = $(TOC_CONTAINER);
-    var elt = top.find('a[href$=\'' + current + '\']');
+    var elt = [];
+    var currentHash = attemptFindCurrentHash(current);
+
+    if (currentHash) {
+        elt = top.find('a[href*=\'' + current + currentHash + '\']');
+    }
+
+    if (elt.length === 0) {
+        elt = top.find('a[href$=\'' + current + '\']');
+    }
 
     if (elt.length === 0) {
         elt = top.find('a[href*=\'' + current + '\']');
@@ -538,14 +557,6 @@ function setUpNotes() {
     $area.on('change', '.note textarea', function(e) {
         handleNoteTextChange($(e.target).closest('.annotation-container'));
     });
-}
-
-function getReaderBody() {
-    'use strict';
-
-    var readerIframe = document.querySelector('#D2Reader-Container iframe');
-    var readerDocument = readerIframe.contentDocument || readerIframe.contentWindow.document;
-    return readerDocument.body;
 }
 
 $(document).on('updateCurrentLocation.d2reader', function() {

--- a/src/frontend/scss/mixins/_site-theme.scss
+++ b/src/frontend/scss/mixins/_site-theme.scss
@@ -541,5 +541,9 @@
         --CT_textPictureColor: #{$text-picture-color};
         --CT_textPictureTermColor: #{$text-picture-term-color};
         --CT_textPictureImgFilter: #{$text-picture-img-filter};
+
+        // Simple notify
+        --CT_notifyBg: #{$notify-bg};
+        --CT_notifyColor: #{$notify-color};
     }
 }

--- a/src/frontend/scss/site-themes/_theme-default.scss
+++ b/src/frontend/scss/site-themes/_theme-default.scss
@@ -606,3 +606,7 @@ $text-replace-color:                    #666;
 $text-picture-color:                    #333;
 $text-picture-term-color:               #333;
 $text-picture-img-filter:               brightness(0) saturate(100%) invert(18%) sepia(37%) saturate(0%) hue-rotate(139deg) brightness(99%) contrast(96%);
+
+// Notify
+$notify-bg:                             $uibase-900;
+$notify-color:                          color-auto-contrast($uibase-900);

--- a/src/frontend/scss/site-themes/_theme-night.scss
+++ b/src/frontend/scss/site-themes/_theme-night.scss
@@ -617,3 +617,7 @@ $text-replace-color:                    #eceff5;
 $text-picture-color:                    #fbfbfb;
 $text-picture-term-color:               #fbfbfb;
 $text-picture-img-filter:               brightness(0) saturate(100%) invert(100%) sepia(86%) saturate(309%) hue-rotate(246deg) brightness(113%) contrast(97%);
+
+// Notify
+$notify-bg:                             #696969;
+$notify-color:                          #fff;

--- a/src/frontend/scss/site-themes/_theme-sepia.scss
+++ b/src/frontend/scss/site-themes/_theme-sepia.scss
@@ -617,3 +617,7 @@ $text-replace-color:                    #666;
 $text-picture-color:                    #333;
 $text-picture-term-color:               #333;
 $text-picture-img-filter:               brightness(0) saturate(100%) invert(18%) sepia(37%) saturate(0%) hue-rotate(139deg) brightness(99%) contrast(96%);
+
+// Notify
+$notify-bg:                             $uibase-900;
+$notify-color:                          color-auto-contrast($uibase-900);

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -490,7 +490,7 @@ h2,
     .text-alt-src {
         //font-weight: bold;
 
-        // stylelint-disabled selector-class-pattern
+        // stylelint-disable selector-class-pattern
         .simplifyLookup,
         .simplifyLookup:hover {
             font-weight: $font-weight-bold;

--- a/src/frontend/scss/site/_notify.scss
+++ b/src/frontend/scss/site/_notify.scss
@@ -1,0 +1,38 @@
+.notify {
+    width: $notify-width;
+    max-width: 100%;
+    padding: $notify-padding-y $notify-padding-x;
+    @include font-size($notify-font-size);
+    color: var(--CT_notifyColor);
+    text-align: $notify-text-align;
+    word-wrap: break-word;
+    pointer-events: auto;
+    background-color: var(--CT_notifyBg);
+    @include border-radius($notify-border-radius);
+
+    &:not(.in) {
+        display: none;
+    }
+    &.in {
+        opacity: 1;
+    }
+}
+
+.notify-container {
+    position: fixed;
+    bottom: $notify-container-bottom;
+    left: 50%;
+    z-index: $notify-container-zindex;
+    width: max-content;
+    max-width: 100%;
+    pointer-events: none;
+    transform: translateX(calc(#{$notify-width} * -.5));
+
+    > * {
+        margin: 0 auto;
+    }
+
+    > :not(:last-child) {
+        margin-bottom: $notify-spacing;
+    }
+}

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -533,3 +533,13 @@ $sort-border-width:                     .3125rem;
 $loader-circle-size:                    2em;
 $loader-circle-border-width:            .25em;
 $loader-circle-vertical-align:          middle;
+
+$notify-spacing:                        1rem;
+$notify-width:                          16rem;
+$notify-padding-y:                      .5rem;
+$notify-padding-x:                      .75rem;
+$notify-font-size:                      .875rem;
+$notify-text-align:                     center;
+$notify-border-radius:                  .375rem;
+$notify-container-bottom:               1.5rem;
+$notify-container-zindex:               1090;

--- a/src/frontend/scss/site/_site.scss
+++ b/src/frontend/scss/site/_site.scss
@@ -28,3 +28,4 @@
 @import "library";
 @import "dashboard";
 @import "wordbank";
+@import "notify";

--- a/src/index.js
+++ b/src/index.js
@@ -48,3 +48,4 @@ import execTTS from "script-loader!../src/frontend/js/tts.js";
 import execSTT from "script-loader!../src/frontend/js/stt.js";
 import execWhy from "script-loader!../src/frontend/js/why.js";
 import execShortcut from "script-loader!../src/frontend/js/shortcut.js";
+import execNotify from "script-loader!../src/frontend/js/notify.js";

--- a/src/shared/templates/shared/base.html
+++ b/src/shared/templates/shared/base.html
@@ -67,5 +67,7 @@
             Timeout warning
         </button>
     {% endif %}
+
+    <div id="notifyContainer" class="notify-container" aria-live="assertive"></div>
 </body>
 </html>

--- a/src/shared/templates/shared/partial/popover_shortcuts.html
+++ b/src/shared/templates/shared/partial/popover_shortcuts.html
@@ -21,6 +21,7 @@
                 <li class="list-item"><kbd class="meta"></kbd> + <kbd>pageUp</kbd> - Previous chapter/section</li>
                 <li class="list-item"><kbd class="meta"></kbd> + <kbd>pageDown</kbd> - Next chapter/section</li>
                 <li class="list-item"><kbd class="meta"></kbd> + <kbd>l</kbd> - Go to the Library page</li>
+                <li class="list-item"><kbd class="meta"></kbd> + <kbd>w</kbd> - Announce current reading position or page</li>
             </ul>
 
             <p>When text is selected within a reading:</p>

--- a/src/shared/templates/shared/partial/popover_tip.html
+++ b/src/shared/templates/shared/partial/popover_tip.html
@@ -78,7 +78,7 @@
     <div class="tooltip-arrow"></div>
     {% endif %}
 </div>
-<div id="features" class="features" aria-live="assertive" aria-atomic="false">
+<div id="features" class="features" aria-live="assertive" aria-atomic="true">
     <div class="content-container container-xl">
         <div class="content">
             <span data-clusive-tip-id="context" data-cfw-tooltip-placement="right auto" class="feature-context feature-novis"></span>


### PR DESCRIPTION
Kind of went a little feature overboard while working on the `Where am I?` feature and some updates to how `aria-live` is used.

- some tweaks to how `aria-live` regions are used for the onboarding tooltips
- new `alt+w`/`option+w` shortcut to announce where you are in a reading, for pages outside of the reader, such as the dashboard or library, the page title is parsed and used.
- added a super simple notification/toast item that appears centered at the bottom of the window so visual users get the same information as a screen-reader for the 'Where am I?' shortcut.
  - section portion will return a nested listing for the current section
- updated handling of the TOC active indicator marker so that pages with multiple linked items can have their nested status updated accordingly.
  - support for both `scroll` and `paged` modes
    - `scroll` mode uses middle of scrolling section to determine current location
    - `paged` mode uses the currently visible 'page' to determine current location

Notification showing position and section within the reader:
![Screenshot 2022-07-14 151325](https://user-images.githubusercontent.com/4764134/179066213-a1bb888d-735f-44a2-84ba-f975e5d008ac.png)

Showing the updated TOC active indicator with improved handling for nested links within the same page:
![Screenshot 2022-07-14 151402](https://user-images.githubusercontent.com/4764134/179066211-bf8e9b4b-06c5-4504-b547-9eaaf73350fa.png)

 