### PR TITLE
CSL-1930: Mockup tour popovers, chaining code

### DIFF
--- a/src/frontend/html/popover.html
+++ b/src/frontend/html/popover.html
@@ -20,10 +20,15 @@
 <script src="https://cdn.jsdelivr.net/npm/figuration@4.1.0/dist/js/figuration.min.js" integrity="sha384-mmncPfSUidq1LlOp/43b1c3A1knjWrGnwec26YYujQlzI2YgCmpcSEtsJ/gjJRHT" crossorigin="anonymous"></script>
 <!--<script src="../dist/js/frontend.js"></script>-->
 <script src="../js/frontend.js"></script>
+<script src="../js/tour.js"></script>
 <script src="./js/theme-test.js"></script>
 
 <style>
-.popover {
+body {
+    margin-bottom: 300px;
+}
+
+.popover:not(.popover-tour) {
     position: relative;
     display: block;
     flex: 1 1 auto;
@@ -835,6 +840,164 @@ He never spoke of the softer passions, save with a <span class="text-replace" ro
         </div>
     </div>
 </div>
+
+<hr>
+
+<h2>Tour script tests</h2>
+<p><code>1</code> and <code>2</code> buttons do not invoke popovers themselves since they may be linked to other functionality, as long as it is not another popover.</p>
+
+<div id="tourContainer" class="tour-container" >
+    <!-- touring popovers to use this element for their `container` and `viewport` options -->
+</div>
+
+<div class="row">
+    <div class="col">
+        <button id="tourTest1Btn" type="button" class="btn" data-cfw-popover-target="#tourTest1">1</button>
+        <button id="tourTest2Btn" type="button" class="btn" data-cfw-popover-target="#tourTest2">2</button>
+    </div>
+    <div class="col-auto text-end ms-1">
+        <button id="tourTest0Btn" type="button" class="btn btn-primary btn-round" data-cfw-popover-target="#tourTest0" onclick="tour.chain('#tourTest0');" >
+            Start Tour
+        </button>
+    </div>
+</div>
+
+<div id="tourTest0" class="popover popover-tour popover-scrollable">
+    <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourTest0Btn');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
+    <div class="popover-header">
+        <div class="dialog-tts" role="region" aria-label="Read aloud controls">
+            <div class="tts-inactive">
+                <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud" data-cle-handler="click" data-cle-control="tts-play" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+            </div>
+            <div class="tts-active">
+                <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud" data-cle-handler="click" data-cle-control="tts-pause" data-cle-value="clicked">
+                    <span class="icon-pause" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud" data-cle-handler="click" data-cle-control="tts-resume" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud" data-cle-handler="click" data-cle-control="tts-stop" data-cle-value="clicked">
+                    <span class="icon-stop" aria-hidden="true"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-body">
+        <div class="embed-fluid embed-fluid-16x9">
+            <iframe src="https://www.youtube-nocookie.com/embed/C0DPdy98e4c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="YouTube Video: TEST VIDEO"></iframe>
+        </div>
+        <strong>First Chained Popover</strong>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel velit vitae enim maximus sollicitudin a quis enim.</p>
+        <div class="row gx-0_5 flex-items-center">
+            <div class="col">
+                <a href="#">Learn more <span class="sr-only">about something</span></a>
+            </div>
+            <div class="col-auto">1/3</div>
+            <div class="col-auto">
+                <button type="button" class="btn btn-secondary" onclick="tour.chain('#tourTest1');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-arrow"></div>
+</div>
+
+<div id="tourTest1" class="popover popover-tour popover-scrollable">
+    <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourTest0Btn');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
+    <div class="popover-header">
+        <div class="dialog-tts" role="region" aria-label="Read aloud controls">
+            <div class="tts-inactive">
+                <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud" data-cle-handler="click" data-cle-control="tts-play" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+            </div>
+            <div class="tts-active">
+                <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud" data-cle-handler="click" data-cle-control="tts-pause" data-cle-value="clicked">
+                    <span class="icon-pause" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud" data-cle-handler="click" data-cle-control="tts-resume" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud" data-cle-handler="click" data-cle-control="tts-stop" data-cle-value="clicked">
+                    <span class="icon-stop" aria-hidden="true"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-body">
+        <div class="embed-fluid embed-fluid-16x9">
+            <iframe src="https://www.youtube-nocookie.com/embed/C0DPdy98e4c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="YouTube Video: TEST VIDEO"></iframe>
+        </div>
+        <strong>Second Chained Popover</strong>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel velit vitae enim maximus sollicitudin a quis enim.</p>
+        <div class="row gx-0_5 flex-items-center">
+            <div class="col">
+                <a href="#">Learn more <span class="sr-only">about something</span></a>
+            </div>
+            <div class="col-auto">
+                <button type="button" class="btn btn-primary" onclick="tour.chain('#tourTest1');"><span class="fa fa-chevron-left" aria-hidden="true"></span> Prev</button>
+            </div>
+            <div class="col-auto">2/3</div>
+            <div class="col-auto">
+                <button type="button" class="btn btn-secondary" onclick="tour.chain('#tourTest2');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-arrow"></div>
+</div>
+
+<div id="tourTest2" class="popover popover-tour popover-scrollable">
+    <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourTest0Btn');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
+    <div class="popover-header">
+        <div class="dialog-tts" role="region" aria-label="Read aloud controls">
+            <div class="tts-inactive">
+                <button type="button" class="btn btn-tool tts-play" aria-label="Read aloud" title="Read aloud" data-cle-handler="click" data-cle-control="tts-play" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+            </div>
+            <div class="tts-active">
+                <button type="button" class="btn btn-tts tts-pause" aria-label="Pause read aloud" title="Pause read aloud" data-cle-handler="click" data-cle-control="tts-pause" data-cle-value="clicked">
+                    <span class="icon-pause" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-resume" aria-label="Resume read aloud" title="Resume read aloud" data-cle-handler="click" data-cle-control="tts-resume" data-cle-value="clicked">
+                    <span class="icon-play" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="btn btn-tts tts-stop" aria-label="Stop read aloud" title="Stop read aloud" data-cle-handler="click" data-cle-control="tts-stop" data-cle-value="clicked">
+                    <span class="icon-stop" aria-hidden="true"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-body">
+        <div class="embed-fluid embed-fluid-16x9">
+            <iframe src="https://www.youtube-nocookie.com/embed/C0DPdy98e4c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="YouTube Video: TEST VIDEO"></iframe>
+        </div>
+        <strong>Third Chained Popover</strong>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel velit vitae enim maximus sollicitudin a quis enim.</p>
+        <div class="row gx-0_5 flex-items-center">
+            <div class="col">
+                <a href="#">Learn more <span class="sr-only">about something</span></a>
+            </div>
+            <div class="col-auto">
+                <button type="button" class="btn btn-primary" onclick="tour.chain('#tourTest1');"><span class="fa fa-chevron-left" aria-hidden="true"></span> Prev</button>
+            </div>
+            <div class="col-auto">2/3</div>
+            <div class="col-auto">
+                <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourTest0Btn');">End</button>
+            </div>
+        </div>
+    </div>
+    <div class="popover-arrow"></div>
+</div>
+
+<script>
+$(window).ready(function() {
+    tour.prepare('#tourTest0Btn');
+    tour.prepare('#tourTest1Btn');
+    tour.prepare('#tourTest2Btn');
+});
+</script>
 
             </main>
         </div>

--- a/src/frontend/html/popover.html
+++ b/src/frontend/html/popover.html
@@ -936,7 +936,7 @@ He never spoke of the softer passions, save with a <span class="text-replace" ro
                 <a href="#">Learn more <span class="sr-only">about something</span></a>
             </div>
             <div class="col-auto">
-                <button type="button" class="btn btn-primary" onclick="tour.chain('#tourTest1');"><span class="fa fa-chevron-left" aria-hidden="true"></span> Prev</button>
+                <button type="button" class="btn btn-primary" onclick="tour.chain('#tourTest0');"><span class="fa fa-chevron-left" aria-hidden="true"></span> Prev</button>
             </div>
             <div class="col-auto">2/3</div>
             <div class="col-auto">
@@ -982,7 +982,7 @@ He never spoke of the softer passions, save with a <span class="text-replace" ro
             <div class="col-auto">
                 <button type="button" class="btn btn-primary" onclick="tour.chain('#tourTest1');"><span class="fa fa-chevron-left" aria-hidden="true"></span> Prev</button>
             </div>
-            <div class="col-auto">2/3</div>
+            <div class="col-auto">3/3</div>
             <div class="col-auto">
                 <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourTest0Btn');">End</button>
             </div>

--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -1,0 +1,71 @@
+(function($) {
+    'use strict';
+
+    var SELECTOR_CONTAINER = '#tourContainer';
+    var SELECTOR_TOUR_VISIBLE = '.popover-tour:visible';
+
+    var tourModule = function() {
+        // placeholder
+    };
+
+    tourModule.prototype = {
+        // Initialize tour popover item
+        // `selector` - the trigger for the popover to initialize
+        prepare : function(selector) {
+            if (selector) {
+                var control = $(selector);
+                // var popover = $(control.attr('data-cfw-popover-target'));
+                var placement = control.attr('data-cfw-popover-placement');
+                control.CFW_Popover({
+                    container: SELECTOR_CONTAINER,
+                    viewport: 'window',
+                    trigger: 'manual',
+                    placement: placement ? placement : 'bottom auto',
+                    popperConfig: {
+                        positionFixed: true
+                    }
+                });
+            }
+        },
+
+        // Chain animations for tour items together
+        // `selector` - the next popover in the chain
+        chain: function(selector) {
+            var $curr = $(document).find(SELECTOR_TOUR_VISIBLE);
+            var $next = $(selector);
+
+            if ($curr.length) {
+                // Wait until hide animation is complete before callling show
+                $curr.CFW_Popover('hide').CFW_transition(null, function() {
+                    $next.CFW_Popover('show');
+                    $next[0].focus();
+                });
+            } else {
+                $next.CFW_Popover('show');
+                $next[0].focus();
+            }
+
+            return false;
+        },
+
+        // Close and refocus
+        // `selector` - item to focus on after popover is hidden
+        closeRefocus : function(selector) {
+            var $curr = $(document).find(SELECTOR_TOUR_VISIBLE);
+            var $next = $(selector);
+
+            if ($curr.length) {
+                // Wait until hide animation is complete before focusing
+                $curr.CFW_Popover('hide').CFW_transition(null, function() {
+                    $next[0].focus();
+                });
+            } else {
+                $next[0].focus();
+            }
+
+            return false;
+        }
+    };
+
+    window.tour = tourModule.prototype;
+}(jQuery));

--- a/src/frontend/scss/mixins/_site-theme.scss
+++ b/src/frontend/scss/mixins/_site-theme.scss
@@ -291,6 +291,12 @@
         --CT_popoverFooterColor: #{$popover-footer-color};
         --CT_popoverFooterBorderColor: #{$popover-footer-border-color};
         --CT_popoverSectionBorderColor: #{$popover-section-border-color};
+        --CT_popoverTourBg: #{$popover-tour-bg};
+        --CT_popoverTourBorderColor: #{$popover-tour-border-color};
+        --CT_popoverTourHeaderBg: #{$popover-tour-header-bg};
+        --CT_popoverTourHeaderBorderColor: #{$popover-tour-header-border-color};
+        --CT_popoverTourFooterBg: #{$popover-tour-footer-bg};
+        --CT_popoverTourFooterBorderColor: #{$popover-tour-footer-border-color};
 
         --CT_popoverTabBg: #{$popover-tab-bg};
         --CT_popoverTabColor: #{$popover-tab-color};

--- a/src/frontend/scss/site-themes/_theme-default.scss
+++ b/src/frontend/scss/site-themes/_theme-default.scss
@@ -324,6 +324,12 @@ $popover-footer-bg:                     #acfdf0;
 $popover-footer-color:                  #333;
 $popover-footer-border-color:           #d3cfc9;
 $popover-section-border-color:          #d3cfc9;
+$popover-tour-bg:                       #97ebdd;
+$popover-tour-border-color:             $popover-border-color;
+$popover-tour-header-bg:                transparent;
+$popover-tour-header-border-color:      transparent;
+$popover-tour-footer-bg:                transparent;
+$popover-tour-footer-border-color:      transparent;
 
 // Popover header tabs
 $popover-tab-bg:                        transparent;

--- a/src/frontend/scss/site-themes/_theme-night.scss
+++ b/src/frontend/scss/site-themes/_theme-night.scss
@@ -336,6 +336,12 @@ $popover-footer-bg:                     #272727;
 $popover-footer-color:                  #fbfbfb;
 $popover-footer-border-color:           #363740;
 $popover-section-border-color:          #363740;
+$popover-tour-bg:                       #272727;
+$popover-tour-border-color:             $popover-border-color;
+$popover-tour-header-bg:                transparent;
+$popover-tour-header-border-color:      transparent;
+$popover-tour-footer-bg:                transparent;
+$popover-tour-footer-border-color:      transparent;
 
 // Popover header tabs
 $popover-tab-bg:                        transparent;

--- a/src/frontend/scss/site-themes/_theme-sepia.scss
+++ b/src/frontend/scss/site-themes/_theme-sepia.scss
@@ -335,6 +335,12 @@ $popover-footer-bg:                     #dad5cc;
 $popover-footer-color:                  #333;
 $popover-footer-border-color:           #d3cfca;
 $popover-section-border-color:          #d3cfca;
+$popover-tour-bg:                       #97ebdd;
+$popover-tour-border-color:             $popover-border-color;
+$popover-tour-header-bg:                transparent;
+$popover-tour-header-border-color:      transparent;
+$popover-tour-footer-bg:                transparent;
+$popover-tour-footer-border-color:      transparent;
 
 // Popover header tabs
 $popover-tab-bg:                        transparent;

--- a/src/frontend/scss/site/_popover.scss
+++ b/src/frontend/scss/site/_popover.scss
@@ -224,3 +224,136 @@
         }
     }
 }
+
+
+.popover-tour {
+    background-color: var(--CT_popoverTourBg);
+    border-color: var(--CT_popoverTourBorderColor);
+    border-width: $popover-tour-border-width;
+
+    @include media-breakpoint-up(md) {
+        width: $popover-tour-md-width;
+        max-width: $popover-tour-md-width;
+    }
+
+    .popover-header {
+        background-color: var(--CT_popoverTourHeaderBg);
+        border-color: var(--CT_popoverTourHeaderBorderColor);
+        @include border-radius($popover-tour-inner-border-radius $popover-tour-inner-border-radius 0 0);
+    }
+    .popover-footer {
+        background-color: var(--CT_popoverTourFooterBg);
+        border-color: var(--CT_popoverTourFooterBorderColor);
+        @include border-radius(0 0 $popover-tour-inner-border-radius $popover-tour-inner-border-radius);
+    }
+
+    @if $enable-popover-arrow {
+        .popover-arrow {
+            position: absolute;
+            display: block;
+            width: $popover-tour-arrow-width;
+            height: $popover-tour-arrow-height;
+            margin: 0 $popover-tour-border-radius;
+
+            &::before,
+            &::after {
+                position: absolute;
+                display: block;
+                content: "";
+                border-color: transparent;
+                border-style: solid;
+            }
+        }
+
+        // Offset the popover to account for the popover arrow
+
+        /* rtl:begin:ignore */
+        &[x-placement^="top"] {
+            margin-bottom: add($popover-tour-arrow-height, $popover-margin);
+
+            > .popover-arrow {
+                bottom: subtract(-$popover-tour-arrow-height, $popover-tour-border-width);
+
+                &::before {
+                    bottom: 0;
+                    border-width: $popover-tour-arrow-height ($popover-tour-arrow-width * .5) 0;
+                    border-top-color: $popover-tour-arrow-outer-color;
+                }
+
+                &::after {
+                    bottom: $popover-tour-border-width;
+                    border-width: $popover-tour-arrow-height ($popover-tour-arrow-width * .5) 0;
+                    border-top-color: $popover-tour-arrow-color;
+                }
+            }
+        }
+
+        &[x-placement^="right"] {
+            margin-left: add($popover-tour-arrow-height, $popover-margin);
+
+            > .popover-arrow {
+                left: subtract(-$popover-tour-arrow-height, $popover-tour-border-width);
+                width: $popover-tour-arrow-height;
+                height: $popover-tour-arrow-width;
+                margin: $popover-border-radius 0; // make sure the arrow does not touch the popover's rounded corners
+
+                &::before {
+                    left: 0;
+                    border-width: ($popover-tour-arrow-width * .5) $popover-tour-arrow-height ($popover-tour-arrow-width * .5) 0;
+                    border-right-color: $popover-tour-arrow-outer-color;
+                }
+
+                &::after {
+                    left: $popover-tour-border-width;
+                    border-width: ($popover-tour-arrow-width * .5) $popover-tour-arrow-height ($popover-tour-arrow-width * .5) 0;
+                    border-right-color: $popover-tour-arrow-color;
+                }
+            }
+        }
+
+        &[x-placement^="bottom"] {
+            margin-top: add($popover-tour-arrow-height, $popover-margin);
+
+            > .popover-arrow {
+                top: subtract(-$popover-tour-arrow-height, $popover-tour-border-width);
+
+                &::before {
+                    top: 0;
+                    border-width: 0 ($popover-tour-arrow-width * .5) $popover-tour-arrow-height ($popover-tour-arrow-width * .5);
+                    border-bottom-color: $popover-tour-arrow-outer-color;
+                }
+
+                &::after {
+                    top: $popover-tour-border-width;
+                    border-width: 0 ($popover-tour-arrow-width * .5) $popover-tour-arrow-height ($popover-tour-arrow-width * .5);
+                    border-bottom-color: $popover-tour-arrow-color;
+                }
+            }
+        }
+
+        &[x-placement^="left"] {
+            margin-right: add($popover-tour-arrow-height, $popover-margin);
+
+            > .popover-arrow {
+                right: subtract(-$popover-tour-arrow-height, $popover-tour-border-width);
+                width: $popover-tour-arrow-height;
+                height: $popover-tour-arrow-width;
+                margin: $popover-border-radius 0; // make sure the arrow does not touch the popover's rounded corners
+
+                &::before {
+                    right: 0;
+                    border-width: ($popover-tour-arrow-width * .5) 0 ($popover-tour-arrow-width * .5) $popover-tour-arrow-height;
+                    border-left-color: $popover-tour-arrow-outer-color;
+                }
+
+                &::after {
+                    right: $popover-tour-border-width;
+                    border-width: ($popover-tour-arrow-width * .5) 0 ($popover-tour-arrow-width * .5) $popover-tour-arrow-height;
+                    border-left-color: $popover-tour-arrow-color;
+                }
+            }
+        }
+
+        /* rtl:end:ignore */
+    }
+}

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -107,7 +107,7 @@ $enable-utility-pointer-events:         false;
 $enable-utility-flex-order:             true;
 $enable-utility-flex-direction:         false;
 $enable-utility-flex-wrap:              false;
-$enable-utility-flex-justify:           false;
+$enable-utility-flex-justify:           true;
 $enable-utility-flex-items:             true;
 $enable-utility-flex-content:           false;
 $enable-utility-flex-self:              false;
@@ -240,8 +240,8 @@ $list-item-active-bg:                   unset;
 $list-item-active-color:                unset;
 $list-bulleted-content:                 "\00a0\2022";
 
-$list-spaced-condensed-padding-y:       .5rem !default;
-$list-spaced-condensed-padding-x:       1rem !default;
+$list-spaced-condensed-padding-y:       .5rem;
+$list-spaced-condensed-padding-x:       1rem;
 
 $table-bg-active:                       var(--CT_tableActiveBg);
 $table-border-color:                    var(--CT_tableBorderColor);
@@ -279,11 +279,11 @@ $form-range-track-bg:                   var(--CT_formRangeTrackBg);
 $form-range-thumb-width:                1.25rem;
 $form-range-thumb-bg:                   var(--CT_formRangeThumbBg);
 $form-range-thumb-box-shadow:           .125rem .125rem 0 .025rem rgba(var(--CT_formRangeThumbBoxShadowRGB), var(--CT_formRangeThumbBoxShadowOpacity));
-$form-range-thumb-focus-box-shadow:     0 0 0 .1875rem rgba(var(--CT_formRangeThumbFocusBoxShadowRGB), var(--CT_formRangeThumbFocusBoxShadowOpacity)) !default;
+$form-range-thumb-focus-box-shadow:     0 0 0 .1875rem rgba(var(--CT_formRangeThumbFocusBoxShadowRGB), var(--CT_formRangeThumbFocusBoxShadowOpacity));
 $form-range-thumb-active-bg:            var(--CT_formRangeThumbActiveBg);
 
 $form-switch-width:                         3rem;
-$form-switch-gutter:                        calc(#{$form-switch-width} + .25em) !default;
+$form-switch-gutter:                        calc(#{$form-switch-width} + .25em);
 $form-switch-track-height:                  1.75rem;
 $form-switch-track-bg:                      var(--CT_formSwitchTrackBg);
 $form-switch-track-border-color:            var(--CT_formSwitchTrackBorderColor);
@@ -376,6 +376,16 @@ $popover-comp-md-width:                 22rem;
 $popover-control-padding-y:             .25rem;
 $popover-control-padding-x:             .25rem;
 $popover-simplify-md-width:             29rem;
+
+$popover-tour-bg:                       var(--CT_popoverTourBg);
+$popover-tour-border-width:             5px;
+$popover-tour-border-radius:            .875rem;
+$popover-tour-inner-border-radius:      subtract($popover-tour-border-radius, $popover-tour-border-width);
+$popover-tour-arrow-width:              1.25rem;
+$popover-tour-arrow-height:             .625rem;
+$popover-tour-arrow-color:              $popover-tour-bg;
+$popover-tour-arrow-outer-color:        $popover-border-color;
+$popover-tour-md-width:                 25rem;
 
 $modal-backdrop-bg:                     var(--CT_modalBackdropBg);
 $modal-backdrop-opacity:                var(--CT_modalBackdropOpacity);

--- a/src/index.js
+++ b/src/index.js
@@ -49,3 +49,4 @@ import execSTT from "script-loader!../src/frontend/js/stt.js";
 import execWhy from "script-loader!../src/frontend/js/why.js";
 import execShortcut from "script-loader!../src/frontend/js/shortcut.js";
 import execNotify from "script-loader!../src/frontend/js/notify.js";
+import execTour from "script-loader!../src/frontend/js/tour.js";


### PR DESCRIPTION
Base layout and styling for tour popovers, also referred to as the 'tooltip' tour.

Contains basic chaining functionality to move between popovers through the use of CSS selectors.  The selectors used in the function calls refer to the trigger element even though the triggers will not actually invoke the show/hide of the popover. The 'trigger' will be where the 'arrow' portion of the popover will point to.  

Currently each popover needs to be initialized through the `tour.prepare(selector)`.

A 'start tour' button will be used to begin the tour, and movement through the chain will be controlled through links in each popover, using `tour.chain(selector)`.   Included is a a customized close routine, `tour.closeRefocus(selector)` to close the popover tour and return focus to a specified element, most likely the 'start tour' button.

How the chain gets put together is potentially a sticking point as it could be contextual based on page, user role, visible panel (?), and possibly other parameters.  Depending on the featured item on the page a custom element may be needed as a hidden trigger to get proper alignment of the popover.  