### PR TITLE
Address CSL-1851 dashboard QA comments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,16 +12,17 @@ Note: all steps between **Create/Activitate Virtual Environment** and **Create a
 
 * [Python 3](https://www.python.org/downloads/)
   * Version 3.7.4 up to 3.9. (3.10+ not tested yet). On Mac, Homebrew is the easiest way to install.
-* Django 3
-  * Version 3.2.14+, installed with other Python dependencies as documented in
+* Django
+  * Version 3.2, installed with other Python dependencies as documented in
     section [Install Python Dependencies](#install-python-dependencies).
 * [virtualenv](https://virtualenv.pypa.io/en/latest/) 
-  * Not required, but highly recommended for maintaining an isolated environment and dependencies.
+  * Not required, but highly recommended for maintaining an isolated environment for Python and Python packages.
 * [Postgres](https://www.postgresql.org/) 
   * Version 11.5 or later. Used in the deployment configuration.
 * [Node.js](https://nodejs.org/)
-  * Version 16 or later. Not required to run the Clusive server, but for development it is needed. 
-    since we use:
+  * Version 16 or 17 (18 is not compatible with [node-sass](https://github.com/sass/node-sass/releases/tag/v7.0.1)). 
+    Not required to run the Clusive server, but for development it is needed. 
+    since the build and install process uses:
     * [npm](https://www.npmjs.com/get-npm) - Package manager
     * [Grunt](https://gruntjs.com/) - Task runner
 

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -211,7 +211,7 @@ class Book(models.Model):
     def get_featured_books(cls):
         """Return books to suggest to users who have not visited any book yet.
         This is really just a stub so far; returns "Clues to Clusive" if it exists."""
-        return Book.objects.filter(owner=None, title__contains='Clusive')
+        return Book.objects.filter(owner=None, title__contains='Clusive', resource_identifier__isnull=True)
 
     class Meta:
         ordering = ['title']

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_student_messages.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_student_messages.html
@@ -7,7 +7,7 @@
         {% else %}
             These are your 3 most recently assigned readings.
         {% endif %}
-        See all assigned readings for this class in the
+        See all assigned readings for your class in the
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
     {% endif %}
 {% elif data.view == 'recent' %}

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_teacher_messages.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_teacher_messages.html
@@ -7,9 +7,9 @@
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
     {% else %}
         {% if data.total < 4 %}
-            These are your most recently assigned readings.
+            These are the readings you most recently assigned to this class.
         {% else %}
-            These are your 3 most recently assigned readings.
+            These are the 3 readings you most recently assigned to this class.
         {% endif %}
         See all assigned readings for this class in the
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>.

--- a/src/shared/templates/shared/partial/site_header_actions.html
+++ b/src/shared/templates/shared/partial/site_header_actions.html
@@ -16,6 +16,7 @@ Expects context:
         {% endif %}
     </li>
 
+    {% if request.clusive_user.can_manage_periods %}
     <li class="nav-item">
         {% url 'resources' as link_url %}
         {% if request.path == link_url or page_group_main == 'resources' %}
@@ -24,6 +25,7 @@ Expects context:
         <a href="{{ link_url }}" class="nav-link{% if page_group == 'resources' %} current{% endif %}">Resources</a>
         {% endif %}
     </li>
+    {% endif %}
 
     <li class="nav-item">
         {% url 'reader_index' as link_url %}


### PR DESCRIPTION
This PR addresses both changes to the messages and the duplicate titles for a guest user when viewing the "Popular" panel.

The message modifications where based on [comment 5288](https://castudl.atlassian.net/browse/CSL-1851?focusedCommentId=35288) in the JIRA.

Regarding the duplicate books issue, [Django QuerySets](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.distinct) support a`distinct(fieldName)` method that could be used to remove duplicates from the book trends, i.e. `distinct('book')`.  But:
1. `distinct(fieldName)` is supported by PostgreSQL only, and
2. `order_by('book')` must be used in conjunction with `distinct('book')`.  But, `order_by('-popularity')` is what is desired here.  It might be possible to order by popularity after the duplicate books are removed from the set; not sure.

While there may be a way to use `distinct()` in our case, for now I have implemented a function that removes duplicated books from the set of book trends.  It does the job and works with SQLite.

JIRA: https://castudl.atlassian.net/browse/CSL-1851