### PR TITLE
CSL-1851: Improve guest+popular response time

### DIFF
--- a/src/clusive_project/settings_local.py
+++ b/src/clusive_project/settings_local.py
@@ -37,7 +37,7 @@ DATABASES = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'cisl@cast.org'
 
-# Log database queries
+# To log database queries, change the level here to DEBUG
 LOGGING['loggers']['django.db.backends'] = {
     'handlers': ['console'],
     'level': 'INFO',

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -8,7 +8,7 @@ from json import JSONDecodeError
 
 from django.core.files.storage import default_storage
 from django.db import models
-from django.db.models import Sum, Q
+from django.db.models import Sum, Q, QuerySet
 from django.utils import timezone
 
 from roster.models import ClusiveUser, Period, Roles, StudentActivitySort
@@ -379,15 +379,17 @@ class BookTrend(models.Model):
         return '<BookTrend %s/%s>' % (self.book, self.period)
 
     @classmethod
-    def top_trends(cls, period):
+    def top_trends(cls, period) -> QuerySet:
         """
-        Return the set of books in the given period, ordered by popularity.  If
-        no period given, return all books, ordered by popularity.
+        Return the set of books in the given period, ordered by popularity.
+        If no period given, return top trends for public books in any Period, ordered by popularity.
         """
         if period:
             return cls.objects.filter(period=period, book__resource_identifier__isnull=True).order_by('-popularity')
         else:
-            return cls.objects.filter(book__resource_identifier__isnull=True).order_by('-popularity')
+            # No Period, therefore public books only since there can be nothing shared.
+            return cls.objects.filter(book__owner=None, book__resource_identifier__isnull=True).order_by('-popularity')
+        trends = trends.filter() # limit to public readings
 
     @classmethod
     def top_assigned(cls, period):

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_data.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_data.html
@@ -20,14 +20,10 @@
     <div class="tab-pane" id="popularTab0">
         <div class="library-grid dashboard-grid">
             {% for item in data.all %}
-                {% if view == 'recent' %}
-                    {% include "library/partial/library_card.html" with book=item.book show_starred=True show_description=True show_menu=False show_topics=False link_stretch=True %}
-                {% elif data.view == 'assigned' and is_guest %}
-                    {% include "library/partial/library_card.html" with book=item show_starred=True show_description=True show_menu=False show_topics=False link_stretch=True %}
-                {% elif is_teacher %}
-                    {% include "library/partial/library_card.html" with book=item.trend.book unauthorized=item.unauthorized read_count_data=item.user_count graph_data=item.comp_check graph_link_prefix="comp-detail-all" graph_link_serial=forloop.counter custom_link_prefix="custom-detail-all" custom_question_data=item.customization show_starred=True show_description=False show_topics=False show_assignments=True show_menu=True %}
+                {% if is_teacher %}
+                    {% include "library/partial/library_card.html" with book=item.book show_starred=True show_description=False show_menu=True show_topics=False show_assignments=True unauthorized=item.unauthorized read_count_data=item.user_count graph_data=item.comp_check graph_link_prefix="comp-detail-all" graph_link_serial=forloop.counter custom_link_prefix="custom-detail-all" custom_question_data=item.customization %}
                 {% else %}
-                    {% include "library/partial/library_card.html" with book=item.trend.book unauthorized=item.unauthorized show_starred=True show_description=True show_menu=True %}
+                    {% include "library/partial/library_card.html" with book=item.book show_starred=True show_description=True  show_menu=False %}
                 {% endif %}
             {% endfor %}
         </div>

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_guest_messages.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_guest_messages.html
@@ -1,16 +1,16 @@
 {% if data.view == 'assigned' %}
-    A list of recently assigned readings displays for students with a
+    A list of recently assigned readings displays here for students with a
     Clusive account connected with a teacher.
 {% elif data.view == 'recent' %}
     {% if data.all|length == 0 %}
-        You have no recent readings yet. Go to the 
+        You have no recent readings yet. Go to the
         <a href="{% url 'library_style_redirect' view='public' %}">library</a>
         and get started in Clusive!
     {% else %}
         Revisit something you've read, or head to the
         <a href="{% url 'library_style_redirect' view='public' %}">library</a>
         for something new.
-    {% endif %}    
+    {% endif %}
 {% elif data.view == 'popular' %}
     {% if data.all|length == 0 %}
        There are no readings popular with Clusive readers right now. Once they

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_student_messages.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_student_messages.html
@@ -2,17 +2,17 @@
     {% if data.all|length == 0 %}
         Here’s where you’ll see readings assigned by your teacher.
     {% else %}
-        {% if data.total < 4 %}
-            These are your most recently assigned readings.
-        {% else %}
+        {% if data.is_truncated %}
             These are your 3 most recently assigned readings.
+        {% else %}
+            These are your assigned readings.
         {% endif %}
         See all assigned readings for your class in the
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
     {% endif %}
 {% elif data.view == 'recent' %}
     {% if data.all|length == 0 %}
-        You have no recent readings yet. Go to the 
+        You have no recent readings yet. Go to the
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>
         and get started in Clusive!
     {% else %}

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads_teacher_messages.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads_teacher_messages.html
@@ -1,15 +1,15 @@
 {% if data.view == 'assigned' %}
     {% if data.all|length == 0 %}
-        Your students haven't done any assigned reading, yet. Assign
-        them something to read by clicking the
+        No readings are assigned to this class.
+        Assign them something to read by clicking the
         <span class="icon-ellipsis-vert"></span> (more actions) icon in
         the lower right of any reading panel in the
-        <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
+        <a href="{% url 'reader_index' %}">library</a>.
     {% else %}
-        {% if data.total < 4 %}
-            These are the readings you most recently assigned to this class.
-        {% else %}
+        {% if data.is_truncated %}
             These are the 3 readings you most recently assigned to this class.
+        {% else %}
+            These are the readings assigned to this class.
         {% endif %}
         See all assigned readings for this class in the
         <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
@@ -20,7 +20,7 @@
         something to read by clicking the
         <span class="icon-ellipsis-vert"></span> (more actions) icon in
         the lower right of any reading panel in the
-        <a href="{% url 'library_style_redirect' view='period' %}">library</a>.
+        <a href="{% url 'reader_index' %}">library</a>library</a>.
     {% else %}
         See what your students are reading and what they said about what
         they learned.

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -31,7 +31,6 @@ from library.models import Book, BookVersion, Paradata, Annotation, BookTrend, \
 from roster.models import ClusiveUser, Period, Roles, UserStats, Preference
 from tips.models import TipHistory, CTAHistory, CompletionType
 from translation.util import TranslateApiManager
-import pdb
 
 logger = logging.getLogger(__name__)
 
@@ -316,9 +315,17 @@ def get_popular_reads_data(clusive_user, periods, current_period, assigned_only)
             # 2. Should use `order_by(book)` in conjunction with `distinct()`,
             # but the goal here is to order by `popularity`.  See:
             # https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.distinct
-            readings = unique_books(readings)
-        total = len(readings)
-        trends = cull_unauthorized_from_readings(readings, clusive_user)[:3]
+            if clusive_user.role == 'GU':
+                readings = readings.filter(book__owner=None) # public readings
+                total = len(readings)
+                trends = unique_books(readings)[:3]
+            else:
+                readings = unique_books(readings)
+                total = len(readings)
+                trends = cull_unauthorized_from_readings(readings, clusive_user)[:3]
+        else:
+            total = len(readings)
+            trends = cull_unauthorized_from_readings(readings, clusive_user)[:3]
 
     trend_data = [{'trend': t} for t in trends]
     for td in trend_data:


### PR DESCRIPTION
@bgoldowsky Here is what I've got so far in terms of improving the database hit due to guest+popular panel display.

What this does: for guests, it removes the non-public readings from the top trends before removing duplicate books.  It is noticeably faster than before.  Then again, my database is not that large to begin with, and, even so, I still fell a little delay.

I tried using` iterator()` with no value, with a value of 100, and also 10.  I noticed no difference, but, again, that might be because of the size of my database.  Before filtering out non-public books, the total number of readings was 47.  After the filter it was 18, and then after removing duplicates, it was 8.  I imagine that the totals are much larger on the Q/A server.