### PR TITLE
NOJIRA: Workaround iOS webkit regression issue for text selection

### DIFF
--- a/src/frontend/js/.eslintrc.json
+++ b/src/frontend/js/.eslintrc.json
@@ -5,6 +5,9 @@
     "es6": true,
     "jquery": true
   },
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "extends": "eslint:recommended",
   "plugins": ["compat"],
   "globals": {

--- a/src/frontend/js/tts.js
+++ b/src/frontend/js/tts.js
@@ -955,10 +955,16 @@ clusiveSelection.handleSelectionEnd = function() {
     if (window.getSelection().rangeCount) {
         clusiveSelection.storedRange =  window.getSelection().getRangeAt(0);
     } else {
-        clusiveSelection.storedRange = {
-            collapsed: true
-        };
+        clusiveSelection.resetStoredRange();
     }
+};
+
+clusiveSelection.resetStoredRange = function() {
+    'use strict';
+
+    clusiveSelection.storedRange = {
+        collapsed: true
+    };
 };
 
 clusiveSelection.recreateSelection = function() {
@@ -972,6 +978,7 @@ clusiveSelection.recreateSelection = function() {
             clearTimeout(clusiveSelection.timerRef);
             setTimeout(function() {
                 selectionReset.addRange(clusiveSelection.storedRange);
+                clusiveSelection.resetStoredRange();
                 clusiveSelection.startSelectListen();
                 resolve();
             }, 10);


### PR DESCRIPTION
Selecting text in iOS and clicking a button, such as TTS play, translate, etc, will not work as intended.

This PR resolves the issue for the Clusive-side TTS.  Highlighting is a bit off, but it may have been before since iOS/Safari does not report charLength on `utterance.wordboundary` events

Should the keyboard shortcut options be considered also?  How common is it to use a keyboard with an iPad/iPhone? 

Regression in iOS since January 2022: https://bugs.webkit.org/show_bug.cgi?id=235223 

 Reference for workaround: https://stackoverflow.com/questions/11300590/how-to-captured-selected-text-range-in-ios-after-text-selection-expansion

@aferditamuriqi - this issue might also affect R2D2BC and things such as highlights/annotations, TTS reading selected text (instead of entire page), and passing back the text selection to functionality available in the toolbox/context menu.


