### PR TITLE
CSL-1997/2071: Fix minimum ARI score check for `EARLY_READER` category

### DIFF
--- a/src/library/views.py
+++ b/src/library/views.py
@@ -578,10 +578,11 @@ class MetadataFormView(LoginRequiredMixin, EventMixin, ThemedPageMixin, Settings
 
         # Based on the value of the radio button (a grade range category) choose
         # that category's minimum as the ARI reading level score.
-        # ReadingLevel.min_grade for EARLY_READER radio button is zero,
-        # but ARI scores start at one and a score of zero means "unkonwn" in the
-        # database.  Set to one in that case.
-        ari_level = ReadingLevel(int(form.cleaned_data['reading_category'])).min_grade or 1
+        # ReadingLevel.min_grade for EARLY_READER radio button is negative
+        # infinity, but ARI scores start at one.  Set to one in that case.
+        ari_level = ReadingLevel(int(form.cleaned_data['reading_category'])).min_grade
+        if ari_level == -math.inf:
+            ari_level = 1
         self.save_reading_levels(self.object, self.book_version, ari_level)
 
         messages.success(self.request, 'Reading added. Your uploaded readings are indicated by a personal icon ({icon:user-o}) on your library card.')


### PR DESCRIPTION
@bgoldowsky Here's a fix for the bug when choosing the "Early reader (preK – grade 3)" radio button in the metadata edit form.

The problem was that the code was checking the `ReadingLevel.min_grade` for `None` and changing it to 1 for the `EARLY_READER` category.  It now correctly checks for negative inifnity.

JIRAs
- https://castudl.atlassian.net/browse/CSL-2071
- https://castudl.atlassian.net/browse/CSL-1997