### PR TITLE
CSL-2007: Additional support for eventual chaining

### DIFF
--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -3,6 +3,7 @@
 
     var SELECTOR_CONTAINER = '#tourContainer';
     var SELECTOR_TOUR_VISIBLE = '.popover-tour:visible';
+    var CLASS_TOUR = 'touring';
 
     var tourModule = function() {
         // placeholder
@@ -10,26 +11,38 @@
 
     tourModule.prototype = {
         // Initialize tour popover item
-        // `selector` - the trigger for the popover to initialize
-        prepare : function(selector) {
-            if (selector) {
-                var control = $(selector);
-                var target = control.attr('data-cfw-popover-target');
-                if ((typeof target === 'undefined' || target === false) && control.is('[data-clusive-tip-id]')) {
-                    target = '#tour_' + control.attr('data-clusive-tip-id');
-                }
-                var placement = control.attr('data-cfw-popover-placement');
-                control.CFW_Popover({
-                    container: SELECTOR_CONTAINER,
-                    viewport: 'window',
-                    trigger: 'manual',
-                    target: target,
-                    placement: placement ? placement : 'right auto',
-                    popperConfig: {
-                        positionFixed: true
-                    }
-                });
+        // `name` - name (via data attribute) trigger for the popover to initialize
+        prepare : function(name) {
+            var $control = $('[data-clusive-tip-id="' + name + '"]');
+            if (!$control.length) { return; }
+
+            var target = $control.attr('data-cfw-popover-target');
+            if ((typeof target === 'undefined' || target === false) && $control.is('[data-clusive-tip-id]')) {
+                target = '#tour_' + $control.attr('data-clusive-tip-id');
             }
+            var placement = $control.attr('data-cfw-popover-placement');
+            $control.CFW_Popover({
+                container: SELECTOR_CONTAINER,
+                viewport: 'window',
+                trigger: 'manual',
+                target: target,
+                placement: placement ? placement : 'right auto',
+                popperConfig: {
+                    positionFixed: true
+                }
+            });
+        },
+
+        // Show a singleton from the tour
+        singleton: function(name) {
+            var $control = $('[data-clusive-tip-id="' + name + '"]');
+            if (!$control.length) { return; }
+
+            document.body.classList.remove(CLASS_TOUR);
+            $control.one('afterShow.cfw.popover', function() {
+                document.querySelector('#tour_' + name).focus();
+            });
+            $control.CFW_Popover('show');
         },
 
         // Chain animations for tour items together
@@ -37,6 +50,8 @@
         chain: function(selector) {
             var $curr = $(document).find(SELECTOR_TOUR_VISIBLE);
             var $next = $(selector);
+
+            document.body.classList.add(CLASS_TOUR);
 
             if ($curr.length) {
                 // Wait until hide animation is complete before callling show
@@ -61,9 +76,11 @@
             if ($curr.length) {
                 // Wait until hide animation is complete before focusing
                 $curr.CFW_Popover('hide').CFW_transition(null, function() {
+                    document.body.classList.remove(CLASS_TOUR);
                     $next[0].focus();
                 });
             } else {
+                document.body.classList.remove(CLASS_TOUR);
                 $next[0].focus();
             }
 

--- a/src/frontend/scss/site/_box.scss
+++ b/src/frontend/scss/site/_box.scss
@@ -83,6 +83,16 @@
         background-repeat: no-repeat;
         background-size: contain;
     }
+
+    .tip-mascot {
+        position: absolute;
+        top: calc(var(--CT_boxMascotSize) * -.375);
+        left: calc(1rem + var(--CT_boxMascotSize));
+        display: block;
+        width: 1px;
+        height: 1px;
+        content: "";
+    }
 }
 
 .clusive-reduced-motion {

--- a/src/frontend/scss/site/_button.scss
+++ b/src/frontend/scss/site/_button.scss
@@ -6,7 +6,8 @@
 .btn-nav,
 .btn-setting,
 .btn-tool,
-.btn-tts {
+.btn-tts,
+.btn-mascot-tipped {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -134,4 +135,22 @@
     margin-bottom: $tag-margin-y;
     @include font-size($tag-font-size);
     font-weight: $tag-font-weight;
+}
+
+.btn-mascot-tipped {
+    position: relative;
+
+    &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        display: block;
+        width: 1.75rem;
+        height: calc(1.75rem * #{$img-ratio-mascot-tipped});
+        content: "";
+        background-image: var(--CT_imgMascotTipped);
+        background-repeat: no-repeat;
+        background-size: contain;
+        transform: translate(-50%, -50%);
+    }
 }

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -720,3 +720,14 @@ h2,
         animation-duration: $loader-circle-animation-speed * 2;
     }
 }
+
+body:not(.touring) {
+    .touring-on {
+        display: none;
+    }
+}
+body.touring {
+    .touring-off {
+        display: none;
+    }
+}

--- a/src/frontend/scss/site/_site-pre.scss
+++ b/src/frontend/scss/site/_site-pre.scss
@@ -345,7 +345,7 @@ $tooltip-bg:                            var(--CT_tooltipBg);
 $tooltip-color:                         var(--CT_tooltipColor);
 $tooltip-opacity:                       .95;
 
-$tooltip-feature-max-width:             14rem;
+$tooltip-feature-max-width:             15rem;
 $tooltip-feature-padding-y:             .5rem;
 $tooltip-feature-padding-x:             .75rem;
 $tooltip-feature-font-size:             $font-size-base;

--- a/src/frontend/scss/site/_tooltip.scss
+++ b/src/frontend/scss/site/_tooltip.scss
@@ -88,6 +88,12 @@
     }
 }
 
+.tooltip-tour {
+    .tooltip-action {
+        justify-content: space-between;
+    }
+}
+
 .tooltip-action {
     display: flex;
     align-items: center;

--- a/src/library/templates/library/library.html
+++ b/src/library/templates/library/library.html
@@ -54,9 +54,9 @@
 </main>
 
 {% include "shared/partial/modal_vocab_check.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
+{% if tours %}
+{% include "shared/partial/popover_tour.html" %}
+{% endif %}
 {% if tip_name %}
 {% include "shared/partial/tooltip_tip.html" %}
 {% endif %}

--- a/src/library/templates/library/resources.html
+++ b/src/library/templates/library/resources.html
@@ -42,9 +42,9 @@
     {% endfor %}
 
 </main>
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
+{% if tours %}
+{% include "shared/partial/popover_tour.html" %}
+{% endif %}
 {% if tip_name %}
 {% include "shared/partial/tooltip_tip.html" %}
 {% endif %}

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -392,10 +392,10 @@ class LibraryView(EventMixin, ThemedPageMixin, SettingsPageMixin, LibraryDataVie
         context['search_form'] = self.search_form
         # BEGIN: Sample Tour
         # Sample tour with single item list
+        #context['tip_name'] = self.tip_shown.name if self.tip_shown else None
         context['tip_name'] = None
-        context['tours'] = [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None
+        context['tours'] = [self.tip_shown.name] if self.tip_shown else None
         # END: Sample Tour
-        context['tip_shown'] = self.tip_shown
         context['has_teacher_resource'] = False
         context['has_bookshare_account'] = has_bookshare_account(self.request)
         return context

--- a/src/pages/templates/pages/dashboard.html
+++ b/src/pages/templates/pages/dashboard.html
@@ -61,9 +61,9 @@
 
 </main>
 {% include "shared/partial/modal_vocab_check.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
+{% if tours %}
+{% include "shared/partial/popover_tour.html" %}
+{% endif %}
 {% if tip_name %}
 {% include "shared/partial/tooltip_tip.html" %}
 {% endif %}

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads.html
@@ -1,4 +1,8 @@
 <div class="box box-mascot-tipped">
+    {% if tip_name == "tour" %}
+    <span class="tip-mascot feature-novis" data-clusive-tip-id="tour" data-clusive-tip-action="tour"></span>
+    {% endif %}
+
     {% if is_teacher %}
         <h2>Student reading</h2>
     {% else %}

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -388,9 +388,9 @@ var simplificationTool = "{{ simplification_tool }}";
 </div>
 
 {% include "shared/partial/modal_toc.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
+{% if tours %}
+{% include "shared/partial/popover_tour.html" %}
+{% endif %}
 {% if tip_name %}
 {% include "shared/partial/tooltip_tip.html" %}
 {% endif %}

--- a/src/pages/templatetags/array_helpers.py
+++ b/src/pages/templatetags/array_helpers.py
@@ -1,0 +1,29 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter(is_safe=True)
+def get_index(sequence, position):
+    try:
+        return sequence[position]
+    except:
+        return None
+
+@register.filter(is_safe=True)
+def get_index_prev(sequence, position):
+    if 0 == position:
+        return None
+    try:
+        return sequence[int(position) - 1]
+    except:
+        return None
+
+@register.filter(is_safe=True)
+def get_index_next(sequence, position):
+    if len(sequence) - 1 == position:
+        return None
+    try:
+        return sequence[int(position) + 1]
+    except:
+        return None

--- a/src/pages/templatetags/array_helpers.py
+++ b/src/pages/templatetags/array_helpers.py
@@ -12,7 +12,7 @@ def get_index(sequence, position):
 
 @register.filter(is_safe=True)
 def get_index_prev(sequence, position):
-    if 0 <= position:
+    if 0 >= position:
         return None
     try:
         return sequence[int(position) - 1]

--- a/src/pages/templatetags/array_helpers.py
+++ b/src/pages/templatetags/array_helpers.py
@@ -12,7 +12,7 @@ def get_index(sequence, position):
 
 @register.filter(is_safe=True)
 def get_index_prev(sequence, position):
-    if 0 == position:
+    if 0 <= position:
         return None
     try:
         return sequence[int(position) - 1]

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -725,7 +725,7 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             'tours': [self.tip_shown.name] if self.tip_shown else None,
             #---
             # If a chained tour, set an array of popover names
-            #'tours': ['settings', 'readaloud'],
+            'tours': ['settings', 'readaloud'],
             #---
             # END: Sample Tour
             'has_teacher_resource': True,

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -226,10 +226,10 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         context['clusive_user'] = self.clusive_user
         # BEGIN: Sample Tour
         # Sample tour with single item list
+        #context['tip_name'] = self.tip_shown.name if self.tip_shown else None
         context['tip_name'] = None
-        context['tours'] = [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None
+        context['tours'] = [self.tip_shown.name] if self.tip_shown else None
         # END: Sample Tour
-        context['tip_shown'] = self.tip_shown
         context['has_teacher_resource'] = True
         return context
 
@@ -720,10 +720,14 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             'hide_cues': hide_cues,
             # BEGIN: Sample Tour
             # Sample tour with single item list
+            #'tip_name': self.tip_shown.name if self.tip_shown else None,
             'tip_name': None,
-            'tours': [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None,
+            'tours': [self.tip_shown.name] if self.tip_shown else None,
+            #---
+            # If a chained tour, set an array of popover names
+            #'tours': ['settings', 'readaloud'],
+            #---
             # END: Sample Tour
-            'tip_shown': self.tip_shown,
             'has_teacher_resource': True,
             'customization': customizations[0] if customizations else None,
             'starred': pdata.starred,

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -229,6 +229,12 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         #context['tip_name'] = self.tip_shown.name if self.tip_shown else None
         context['tip_name'] = None
         context['tours'] = [self.tip_shown.name] if self.tip_shown else None
+        #---
+        # If a chained tour, set tooltip to be shown at some point (but not always)
+        # and set an array of popover names
+        #context['tip_name'] = 'tour'
+        #context['tours'] = ['settings', 'readaloud']
+        #---
         # END: Sample Tour
         context['has_teacher_resource'] = True
         return context
@@ -725,7 +731,7 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             'tours': [self.tip_shown.name] if self.tip_shown else None,
             #---
             # If a chained tour, set an array of popover names
-            'tours': ['settings', 'readaloud'],
+            #'tours': ['settings', 'readaloud'],
             #---
             # END: Sample Tour
             'has_teacher_resource': True,

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -232,7 +232,9 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         #---
         # If a chained tour, set tooltip to be shown at some point (but not always)
         # and set an array of popover names
-        #context['tip_name'] = 'tour'
+        # 'cluey' is a special case and uses the older tooltip functionality
+        #context['tip_name'] = 'cluey' if self.tip_shown and self.tip_shown.name == 'cluey' else None # Cluey tooltip
+        #context['tour_singleton'] = self.tip_shown.name if self.tip_shown and self.tip_shown.name != 'cluey' else None # Singleton tour item
         #context['tours'] = ['settings', 'readaloud']
         #---
         # END: Sample Tour

--- a/src/shared/templates/shared/base.html
+++ b/src/shared/templates/shared/base.html
@@ -50,7 +50,10 @@
                     {% block sidebar_bottom_start %}
                     {% include "shared/partial/sidebar_bottom_start.html" with show_reading_feedback=False %}
                     {% endblock%}
+                </div>
+                <div class="sidebar sidebar-end">
                     {% block sidebar_bottom_end %}
+                    {% include "shared/partial/sidebar_bottom_end.html" %}
                     {% endblock%}
                 </div>
             </div>

--- a/src/shared/templates/shared/partial/popover_tour.html
+++ b/src/shared/templates/shared/partial/popover_tour.html
@@ -1,12 +1,10 @@
 {% load i18n %}
+{% load array_helpers %}
 
 {% for name in tours %}
 <div id="tour_{{ name }}" class="popover popover-tour popover-scrollable">
-    {% if tours|length > 1 %}
-    <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourStart');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
-    {% else %}
-    <button type="button" class="close" aria-label="Close" data-cfw-dismiss="popover"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
-    {% endif %}
+    <button type="button" class="close touring-on" aria-label="Close" onclick="tour.closeRefocus('#tourStart');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
+    <button type="button" class="close touring-off" aria-label="Close" data-cfw-dismiss="popover"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
     <div class="popover-header">
         <span class="h3">
         {% if name == "settings" %}
@@ -156,20 +154,17 @@
     <div class="popover-arrow"></div>
     {% endif %}
 </div>
+{% endfor %}
+{% if tours %}
 <script>
 $(window).ready(function() {
-    tour.prepare('[data-clusive-tip-id="{{ name }}"]');
-
-    {% if tours|length == 1 %}
-    var tip_control = document.querySelector('[data-clusive-tip-id="{{ name }}"]');
-    if (tip_control) {
-        var $tip_control = $(tip_control);
-        $tip_control.one('afterShow.cfw.popover', function() {
-            document.querySelector('#tour_{{ name }}').focus();
-        });
-        $tip_control.CFW_Popover('show');
-    }
+    {% for name in tours %}
+    tour.prepare('{{ name }}');
+    {% endfor %}
+    {% if tour_singleton %}
+    tour.singleton('{{ tour_singleton }}');
     {% endif %}
+
 });
 </script>
-{% endfor %}
+{% endif %}

--- a/src/shared/templates/shared/partial/popover_tour.html
+++ b/src/shared/templates/shared/partial/popover_tour.html
@@ -1,6 +1,7 @@
 {% load i18n %}
-<div id="tour_{{ tour_name }}" class="popover popover-tour popover-scrollable">
-    {% if tour_robust %}
+
+{% for name in tours %}
+<div id="tour_{{ name }}" class="popover popover-tour popover-scrollable">
     {% if tours|length > 1 %}
     <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourStart');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
     {% else %}
@@ -8,21 +9,21 @@
     {% endif %}
     <div class="popover-header">
         <span class="h3">
-        {% if tour_name == "settings" %}
+        {% if name == "settings" %}
             Settings
-        {% elif tour_name == "readaloud" %}
+        {% elif name == "readaloud" %}
             Read-aloud
-        {% elif tour_name == "wordbank" %}
+        {% elif name == "wordbank" %}
             Word Bank
-        {% elif tour_name == "switch" %}
+        {% elif name == "switch" %}
             Switch
-        {% elif tour_name == "context" %}
+        {% elif name == "context" %}
             Context
-        {% elif tour_name == "view" %}
+        {% elif name == "view" %}
             Library Views
-        {% elif tour_name == "book_actions" %}
+        {% elif name == "book_actions" %}
             Book Actions
-        {% elif tour_name == "activity" %}
+        {% elif name == "activity" %}
             Activities
         {% endif %}
         </span>
@@ -45,75 +46,54 @@
             </div>
         </div>
     </div>
-    {% endif %}
     <div class="popover-body">
-        {% if tour_name == "settings" %}
+    {% if name == "settings" %}
 <!-- settings -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="settingsIframe" src="https://videos.sproutvideo.com/embed/a79edbb41414e7c72e/96f3dfacf85e2603?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Settings video"></iframe>
         </div>
         <p>Change the font, colors, and more! Settings let you choose the look, supports, and reading tools to make Clusive all your own.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <a href="{% url 'res_reader' resource_id='SSETTINGS' %}">Learn more<span class="sr-only"> about settings</span></a>
-                {% endif %}
-            </div>
-            <div class="tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "readaloud" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SSETTINGS" resource_name="settings" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "readaloud" %}
 <!-- readaloud -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="readaloudIframe" src="https://videos.sproutvideo.com/embed/449edbb51c1ae6cecd/90717ea3b61bbdd3?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Read aloud video"></iframe>
         </div>
         <p>Click the page read aloud icon to hear the entire page. Select text and click read aloud in the context menu to hear a smaller selection or a single word read aloud.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <!-- 'readaloud' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                <a href="#" tabindex="-1"></a>
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "wordbank" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            <!-- 'readaloud' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="" resource_name="" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "wordbank" %}
 <!-- wordbank -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="wordbankIframe" src="https://videos.sproutvideo.com/embed/ac9edbbb161fe1c025/5cb0b244a6a441c9?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Word bank video"></iframe>
         </div>
         <p>The Word bank collects words you’ve looked up or rated. Check out how you’ve rated words. Change ratings as your word knowledge grows. Get back to your previous page by clicking on the back button.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <!-- 'wordbank' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                <a href="#" tabindex="-1"></a>
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "switch" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            <!-- 'wordbank' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="" resource_name="" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "switch" %}
 <!-- switch -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="switchIframe" src="https://videos.sproutvideo.com/embed/d39edbbb161ae0c75a/7acc94350bf3dd31?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Switch video"></iframe>
         </div>
         <p>Switch gives three challenge options for some texts. Open Switch, check out the vocabulary in each version, and choose to stay, or change challenge levels. It’s up to you!</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <a href="{% url 'res_reader' resource_id='SWITCH' %}">Learn more<span class="sr-only"> about switch</span></a>
-                {% endif %}
-            </div>
-            <div class="col-auto tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "context" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SWITCH" resource_name="switch" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "context" %}
 <!-- context -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="contextIframe" src="https://videos.sproutvideo.com/embed/799edbb41410e3c1f0/10056e5843bb7d55?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Context tools video"></iframe>
@@ -125,35 +105,25 @@
             <li><span class="feature-icon icon-switch" aria-hidden="true"></span> Translate or simplify</li>
             <li><span class="feature-icon icon-play-circled2" aria-hidden="true"></span> Hear the words read aloud</li>
         </ul>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <!-- 'context' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                <a href="#" tabindex="-1"></a>
-                {% endif %}
-            </div>
-            <div class="col-auto tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "view" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            <!-- 'context' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="" resource_name="" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "view" %}
 <!-- view -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="viewIframe" src="https://videos.sproutvideo.com/embed/ac9edbbb141fe6c525/86b0cbe36e2ab800?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Library Views video"></iframe>
         </div>
         <p>View the Clusive library by all readings, or in smaller groupings like class readings, readings you’ve starred, public readings, or readings you’ve uploaded.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <!-- 'view' type popovers currently do not have a "Learn more" resource link yet, so this is blank -->
-                <a href="#" tabindex="-1"></a>
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "book_actions" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            <!-- 'view' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="" resource_name="" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "book_actions" %}
 <!-- book_actions -->
         {% if clusive_user.role == 'TE' %}
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
@@ -161,17 +131,12 @@
         </div>
         {% endif %}
         <p>Click “More actions” (three dots) to assign or customize any book, and for books you uploaded to Clusive, to edit information or delete a book.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <a href="{% url 'res_reader' 'CREAD' %}">Learn more<span class="sr-only"> about book actions</span></a>
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
-        {% elif tour_name == "activity" %}
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="CREAD" resource_name="book actions" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
+    {% elif name == "activity" %}
 <!-- activity -->
         {% if clusive_user.role == 'TE' %}
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
@@ -180,35 +145,31 @@
         {% endif %}
         <p>Get a quick overview of student activity. Hover over active reading time bars for titles and reading time. Click a bar to see readings students have in common. Triangles show readings you have assigned.</p>
         <p>Select timeframe and sort by hours, books, or student name.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
-                <a href="{% url 'res_reader' 'READDTL' %}">Learn more<span class="sr-only"> about student activities data</span></a>
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' and has_teacher_resource %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="READDTL" resource_name="student activities data" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% endif %}
+    {% endif %}
     </div>
-    {% if tour_name != "context" and tour_name != "activity" %}
+    {% if name != "context" and name != "activity" %}
     <div class="popover-arrow"></div>
     {% endif %}
 </div>
 <script>
 $(window).ready(function() {
-    tour.prepare('[data-clusive-tip-id="{{ tour_name }}"]');
+    tour.prepare('[data-clusive-tip-id="{{ name }}"]');
 
     {% if tours|length == 1 %}
-    var tip_control = document.querySelector('[data-clusive-tip-id="{{ tour_name }}"]');
+    var tip_control = document.querySelector('[data-clusive-tip-id="{{ name }}"]');
     if (tip_control) {
         var $tip_control = $(tip_control);
         $tip_control.one('afterShow.cfw.popover', function() {
-            document.querySelector('#tour_{{ tour_name }}').focus();
+            document.querySelector('#tour_{{ name }}').focus();
         });
         $tip_control.CFW_Popover('show');
     }
     {% endif %}
 });
 </script>
+{% endfor %}

--- a/src/shared/templates/shared/partial/popover_tour_footer.html
+++ b/src/shared/templates/shared/partial/popover_tour_footer.html
@@ -2,30 +2,27 @@
 {% load array_helpers %}
 
 <div class="row gx-0_5 flex-items-center">
-<div class="col">
-    {% if resource_id %}
-    <a href="{% url 'res_reader' resource_id=resource_id %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+    <div class="col">
+        {% if resource_id %}
+        <a href="{% url 'res_reader' resource_id=resource_id %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+        {% endif %}
+    </div>
+    {% if tours|get_index_prev:forloop.counter0 %}
+    <div class="col-auto touring-on">
+        <button type="button" class="btn btn-primary" onclick="tour.chain('#tour_{{ tours|get_index_prev:forloop.counter0 }}');"><span class="fa fa-chevron-left" aria-hidden="true"></span> <span aria-hidden="true">Prev</span><span class="sr-only">Previous</span></button>
+    </div>
     {% endif %}
-</div>
-{% if tours|length > 1 %}
-{% if tours|get_index_prev:forloop.counter0 %}
-<div class="col-auto">
-    <button type="button" class="btn btn-primary" onclick="tour.chain('#tour_{{ tours|get_index_prev:forloop.counter0 }}');"><span class="fa fa-chevron-left" aria-hidden="true"></span> <span aria-hidden="true">Prev</span><span class="sr-only">Previous</span></button>
-</div>
-{% endif %}
-<div class="col-auto">
-    {{ forloop.counter }}/{{ tours|length }}
-</div>
-<div class="col-auto">
-    {% if tours|get_index_next:forloop.counter0 %}
-    <button type="button" class="btn btn-secondary" onclick="tour.chain('#tour_{{ tours|get_index_next:forloop.counter0 }}');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
-    {% else %}
-    <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourStart');">End</button>
-    {% endif %}
-</div>
-{% else %}
-<div class="col-auto">
-    <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-</div>
-{% endif %}
+    <div class="col-auto touring-on">
+        {{ forloop.counter }}/{{ tours|length }}
+    </div>
+    <div class="col-auto touring-on">
+        {% if tours|get_index_next:forloop.counter0 %}
+        <button type="button" class="btn btn-secondary" onclick="tour.chain('#tour_{{ tours|get_index_next:forloop.counter0 }}');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
+        {% else %}
+        <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourStart');">End</button>
+        {% endif %}
+    </div>
+    <div class="col-auto touring-off">
+        <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
+    </div>
 </div>

--- a/src/shared/templates/shared/partial/popover_tour_footer.html
+++ b/src/shared/templates/shared/partial/popover_tour_footer.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+{% load array_helpers %}
+
+<div class="row gx-0_5 flex-items-center">
+<div class="col">
+    {% if resource_id %}
+    <a href="{% url 'res_reader' resource_id=resource_id %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+    {% endif %}
+</div>
+{% if tours|length > 1 %}
+{% if tours|get_index_prev:forloop.counter0 %}
+<div class="col-auto">
+    <button type="button" class="btn btn-primary" onclick="tour.chain('#tour_{{ tours|get_index_prev:forloop.counter0 }}');"><span class="fa fa-chevron-left" aria-hidden="true"></span> <span aria-hidden="true">Prev</span><span class="sr-only">Previous</span></button>
+</div>
+{% endif %}
+<div class="col-auto">
+    {{ forloop.counter }}/{{ tours|length }}
+</div>
+<div class="col-auto">
+    {% if tours|get_index_next:forloop.counter0 %}
+    <button type="button" class="btn btn-secondary" onclick="tour.chain('#tour_{{ tours|get_index_next:forloop.counter0 }}');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
+    {% else %}
+    <button type="button" class="btn btn-secondary" data-cfw-dismiss="popover">End</button>
+    {% endif %}
+</div>
+{% else %}
+<div class="col-auto">
+    <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
+</div>
+{% endif %}
+</div>

--- a/src/shared/templates/shared/partial/popover_tour_footer.html
+++ b/src/shared/templates/shared/partial/popover_tour_footer.html
@@ -20,7 +20,7 @@
     {% if tours|get_index_next:forloop.counter0 %}
     <button type="button" class="btn btn-secondary" onclick="tour.chain('#tour_{{ tours|get_index_next:forloop.counter0 }}');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
     {% else %}
-    <button type="button" class="btn btn-secondary" data-cfw-dismiss="popover">End</button>
+    <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourStart');">End</button>
     {% endif %}
 </div>
 {% else %}

--- a/src/shared/templates/shared/partial/sidebar_bottom_end.html
+++ b/src/shared/templates/shared/partial/sidebar_bottom_end.html
@@ -1,0 +1,6 @@
+{% load array_helpers %}
+{% if tours %}
+<div class="sidebar-region sidebar-support" role="region" aria-label="User support">
+    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped" onclick="tour.chain('#tour_{{ tours|get_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
+</div>
+{% endif %}

--- a/src/shared/templates/shared/partial/sidebar_bottom_end.html
+++ b/src/shared/templates/shared/partial/sidebar_bottom_end.html
@@ -1,6 +1,10 @@
 {% load array_helpers %}
-{% if tours %}
 <div class="sidebar-region sidebar-support" role="region" aria-label="User support">
-    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped" onclick="tour.chain('#tour_{{ tours|get_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
+    {% if tours %}
+    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped mt-0_75" onclick="tour.chain('#tour_{{ tours|get_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
+    {% else %}
+    <span class="d-inline-block mt-0_75" tabindex="0" title="There are currently no tool tips on this page." data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="reverse">
+        <button type="button" class="btn btn-tool btn-mascot-tipped" disabled><span class="sr-only">There are currently no tool tips on this page.</span></button>
+    </span>
+    {% endif %}
 </div>
-{% endif %}

--- a/src/shared/templates/shared/partial/tooltip_tip.html
+++ b/src/shared/templates/shared/partial/tooltip_tip.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load array_helpers %}
-<div id="tip" class="tooltip tooltip-feature{% if tip_name == "tour" %} tooltip-tour{% endif %}">
+<div id="tip" class="tooltip tooltip-feature{% if tip_name == "tour" %} tooltip-tour{% endif %} ">
     <div class="tooltip-body">
         {% if tip_name == "settings" %}
         <p><strong>Settings:</strong> Change the font, colors, and more!</p>
@@ -73,7 +73,7 @@
                 <span class="d-none open" data-cfw="collapse" data-cfw-collapse-target="#activityFeature0" data-cfw-collapse-animate="false">Previous</span>
             </div>
         </div>
-        {% elif tip_name == "tour" %}
+        {% elif tip_name == "cluey" %}
         <p>To get a tour of this page, click on me in the lower right anytime!</p>
         <div class="tooltip-action">
             <button type="button" class="btn btn-secondary me-0_5" onclick="$('#tip').CFW_Tooltip('hide'); tour.chain('#tour_{{ tours|get_index:0 }}');">Start tour now</button>

--- a/src/shared/templates/shared/partial/tooltip_tip.html
+++ b/src/shared/templates/shared/partial/tooltip_tip.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-<div id="tip" class="tooltip tooltip-feature">
+{% load array_helpers %}
+<div id="tip" class="tooltip tooltip-feature{% if tip_name == "tour" %} tooltip-tour{% endif %}">
     <div class="tooltip-body">
         {% if tip_name == "settings" %}
         <p><strong>Settings:</strong> Change the font, colors, and more!</p>
@@ -71,6 +72,12 @@
                 </div>
                 <span class="d-none open" data-cfw="collapse" data-cfw-collapse-target="#activityFeature0" data-cfw-collapse-animate="false">Previous</span>
             </div>
+        </div>
+        {% elif tip_name == "tour" %}
+        <p>To get a tour of this page, click on me in the lower right anytime!</p>
+        <div class="tooltip-action">
+            <button type="button" class="btn btn-secondary me-0_5" onclick="$('#tip').CFW_Tooltip('hide'); tour.chain('#tour_{{ tours|get_index:0 }}');">Start tour now</button>
+            <button type="button" class="btn btn-primary" data-cfw-dismiss="tooltip">Got it!</button>
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
Pushing a a PR to a PR  to hopefully not blow up work by @klown 

Removed 'robust' flag since this is always true for the current set of popovers. To test the example chain of 2 items
- uncomment the array of names in `src/pages/views.py` at line 728
- go to any publication and in developer console run the command `tour.chain('#tour_settings');` to start the tour
- actual start button has not been added yet as it is still in design

Other changes:
- includes some new template filters to help with the array parsing
- moved the for loop into the `popover_tour.html` template
- moved the 'footer' navigation buttons and learn more links into their own template `popover_tour_footer.html`