### PR TITLE
Feature/csl 2041 popover tour

### DIFF
--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -1298,6 +1298,34 @@ function setUpDeferredLoadOfCompDetails() {
     });
 }
 
+function dialogMediaStop() {
+    'use strict';
+
+    function dialogTarget(evt) {
+        if (evt.namespace.includes('popover')) {
+            return $(evt.target).data('cfw.popover').$target[0];
+        }
+        if (evt.namespace.includes('modal')) {
+            return $(evt.target).data('cfw.modal').$target[0];
+        }
+        return null;
+    }
+
+    $(document.body).on('beforeHide.cfw.popover beforeHide.cfw.modal', function(evt) {
+        var target = dialogTarget(evt);
+        if (target === null) { return; }
+
+        var $iframes = $(target).find('iframe[src]');
+        $iframes.each(function() {
+            var source = this.src;
+            if (source.includes('youtube.com') || source.includes('sproutvideo.com')) {
+                this.src = '';
+                this.src = source;
+            }
+        });
+    });
+}
+
 $(window).ready(function() {
     'use strict';
 
@@ -1328,6 +1356,7 @@ $(window).ready(function() {
     shareForm();
     dashboardStudentReadingViewButtons();
     toolboxHandleUpdate();
+    dialogMediaStop();
 
     var settingFontSize = document.querySelector('#set-size');
     if (settingFontSize !== null) {

--- a/src/frontend/js/frontend.js
+++ b/src/frontend/js/frontend.js
@@ -1312,6 +1312,8 @@ function dialogMediaStop() {
     }
 
     $(document.body).on('beforeHide.cfw.popover beforeHide.cfw.modal', function(evt) {
+        if (evt.isDefaultPrevented()) { return; }
+
         var target = dialogTarget(evt);
         if (target === null) { return; }
 

--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -40,10 +40,8 @@
 
             document.body.classList.remove(CLASS_TOUR);
             $control.one('afterShow.cfw.popover', function() {
-                popoverHelpDialog = $('#tour_' + name).focus();
-                if (popoverHelpDialog.is(':visible')) {
-                    window.parent.clusiveEvents.addTipViewToQueue(name);
-                }
+                document.querySelector('#tour_' + name).focus();
+                window.parent.clusiveEvents.addTipViewToQueue(name);
             });
             setTimeout(function() {
                 $control.CFW_Popover('show');

--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -40,7 +40,10 @@
 
             document.body.classList.remove(CLASS_TOUR);
             $control.one('afterShow.cfw.popover', function() {
-                document.querySelector('#tour_' + name).focus();
+                popoverHelpDialog = $('#tour_' + name).focus();
+                if (popoverHelpDialog.is(':visible')) {
+                    window.parent.clusiveEvents.addTipViewToQueue(name);
+                }
             });
             setTimeout(function() {
                 $control.CFW_Popover('show');

--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -3,6 +3,7 @@
 
     var SELECTOR_CONTAINER = '#tourContainer';
     var SELECTOR_TOUR_VISIBLE = '.popover-tour:visible';
+    var CLASS_TOUR = 'touring';
 
     var tourModule = function() {
         // placeholder
@@ -10,26 +11,38 @@
 
     tourModule.prototype = {
         // Initialize tour popover item
-        // `selector` - the trigger for the popover to initialize
-        prepare : function(selector) {
-            if (selector) {
-                var control = $(selector);
-                var target = control.attr('data-cfw-popover-target');
-                if ((typeof target === 'undefined' || target === false) && control.is('[data-clusive-tip-id]')) {
-                    target = '#tour_' + control.attr('data-clusive-tip-id');
-                }
-                var placement = control.attr('data-cfw-popover-placement');
-                control.CFW_Popover({
-                    container: SELECTOR_CONTAINER,
-                    viewport: 'window',
-                    trigger: 'manual',
-                    target: target,
-                    placement: placement ? placement : 'right auto',
-                    popperConfig: {
-                        positionFixed: true
-                    }
-                });
+        // `name` - name (via data attribute) trigger for the popover to initialize
+        prepare : function(name) {
+            var $control = $('[data-clusive-tip-id="' + name + '"]');
+            if (!$control.length) { return; }
+
+            var target = $control.attr('data-cfw-popover-target');
+            if ((typeof target === 'undefined' || target === false) && $control.is('[data-clusive-tip-id]')) {
+                target = '#tour_' + $control.attr('data-clusive-tip-id');
             }
+            var placement = $control.attr('data-cfw-popover-placement');
+            $control.CFW_Popover({
+                container: SELECTOR_CONTAINER,
+                viewport: 'window',
+                trigger: 'manual',
+                target: target,
+                placement: placement ? placement : 'right auto',
+                popperConfig: {
+                    positionFixed: true
+                }
+            });
+        },
+
+        // Show a singleton from the tour
+        singleton: function(name) {
+            var $control = $('[data-clusive-tip-id="' + name + '"]');
+            if (!$control.length) { return; }
+
+            document.body.classList.remove(CLASS_TOUR);
+            $control.one('afterShow.cfw.popover', function() {
+                document.querySelector('#tour_' + name).focus();
+            });
+            $control.CFW_Popover('show');
         },
 
         // Chain animations for tour items together
@@ -37,6 +50,8 @@
         chain: function(selector) {
             var $curr = $(document).find(SELECTOR_TOUR_VISIBLE);
             var $next = $(selector);
+
+            document.body.classList.add(CLASS_TOUR);
 
             if ($curr.length) {
                 // Wait until hide animation is complete before callling show
@@ -61,9 +76,11 @@
             if ($curr.length) {
                 // Wait until hide animation is complete before focusing
                 $curr.CFW_Popover('hide').CFW_transition(null, function() {
+                    document.body.classList.remove(CLASS_TOUR);
                     $next[0].focus();
                 });
             } else {
+                document.body.classList.remove(CLASS_TOUR);
                 $next[0].focus();
             }
 

--- a/src/frontend/js/tour.js
+++ b/src/frontend/js/tour.js
@@ -42,7 +42,9 @@
             $control.one('afterShow.cfw.popover', function() {
                 document.querySelector('#tour_' + name).focus();
             });
-            $control.CFW_Popover('show');
+            setTimeout(function() {
+                $control.CFW_Popover('show');
+            }, 2000);
         },
 
         // Chain animations for tour items together
@@ -51,15 +53,18 @@
             var $curr = $(document).find(SELECTOR_TOUR_VISIBLE);
             var $next = $(selector);
 
-            document.body.classList.add(CLASS_TOUR);
+            // Hide tip/tour tooltip if showing
+            $('#tip').CFW_Tooltip('hide');
 
             if ($curr.length) {
                 // Wait until hide animation is complete before callling show
                 $curr.CFW_Popover('hide').CFW_transition(null, function() {
+                    document.body.classList.add(CLASS_TOUR);
                     $next.CFW_Popover('show');
                     $next[0].focus();
                 });
             } else {
+                document.body.classList.add(CLASS_TOUR);
                 $next.CFW_Popover('show');
                 $next[0].focus();
             }

--- a/src/frontend/scss/site/_box.scss
+++ b/src/frontend/scss/site/_box.scss
@@ -83,6 +83,16 @@
         background-repeat: no-repeat;
         background-size: contain;
     }
+
+    .tip-mascot {
+        position: absolute;
+        top: calc(var(--CT_boxMascotSize) * -.375);
+        left: calc(1rem + var(--CT_boxMascotSize));
+        display: block;
+        width: 1px;
+        height: 1px;
+        content: "";
+    }
 }
 
 .clusive-reduced-motion {

--- a/src/frontend/scss/site/_button.scss
+++ b/src/frontend/scss/site/_button.scss
@@ -6,7 +6,8 @@
 .btn-nav,
 .btn-setting,
 .btn-tool,
-.btn-tts {
+.btn-tts,
+.btn-mascot-tipped {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -134,4 +135,22 @@
     margin-bottom: $tag-margin-y;
     @include font-size($tag-font-size);
     font-weight: $tag-font-weight;
+}
+
+.btn-mascot-tipped {
+    position: relative;
+
+    &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        display: block;
+        width: 1.75rem;
+        height: calc(1.75rem * #{$img-ratio-mascot-tipped});
+        content: "";
+        background-image: var(--CT_imgMascotTipped);
+        background-repeat: no-repeat;
+        background-size: contain;
+        transform: translate(-50%, -50%);
+    }
 }

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -542,19 +542,13 @@ h2,
 }
 .feature-context {
     position: absolute;
-    //top: 33%;
-    //left: 50%;
-    top: 66%;
-    left: $sidebar-width;
+    top: 25%;
+    left: 50%;
     margin-right: ($grid-gutter-width / -2);
     margin-left: ($grid-gutter-width / -2);
     pointer-events: none;
     outline: 0;
     @include sr-only();
-
-    @include media-breakpoint-up(md) {
-        left: $sidebar-md-width;
-    }
 }
 
 .feature-list {

--- a/src/frontend/scss/site/_content.scss
+++ b/src/frontend/scss/site/_content.scss
@@ -720,3 +720,19 @@ h2,
         animation-duration: $loader-circle-animation-speed * 2;
     }
 }
+
+// stylelint-disable selector-no-qualifying-type
+// Conditionally show/hide content in tour popovers depending on if
+// state is singleton (auto-shown) or part of the tour started from
+// the tour/mascot button
+body:not(.touring) {
+    .touring-on {
+        display: none;
+    }
+}
+body.touring {
+    .touring-off {
+        display: none;
+    }
+}
+// stylelint-enable selector-no-qualifying-type

--- a/src/frontend/scss/site/_tooltip.scss
+++ b/src/frontend/scss/site/_tooltip.scss
@@ -97,3 +97,12 @@
 .tooltip-step {
     margin-right: auto;
 }
+
+.tooltip-tour {
+    .tooltip-body {
+        max-width: 15.5rem;
+    }
+    .tooltip-action {
+        justify-content: space-between;
+    }
+}

--- a/src/library/templates/library/library.html
+++ b/src/library/templates/library/library.html
@@ -54,11 +54,5 @@
 </main>
 
 {% include "shared/partial/modal_vocab_check.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% include "shared/partial/modal_confirm.html" %}
 {% endblock %}

--- a/src/library/templates/library/resources.html
+++ b/src/library/templates/library/resources.html
@@ -42,10 +42,4 @@
     {% endfor %}
 
 </main>
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% endblock %}

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -34,7 +34,7 @@ from oauth2.bookshare.views import has_bookshare_account, is_bookshare_connected
     get_access_keys, is_organization_sponsor, is_organization_member
 from pages.views import ThemedPageMixin, SettingsPageMixin
 from roster.models import ClusiveUser, Period, LibraryViews, LibraryStyles, check_valid_choice
-from tips.models import TipHistory
+from tips.models import TipHistory, TourList
 
 
 logger = logging.getLogger(__name__)
@@ -385,17 +385,15 @@ class LibraryView(EventMixin, ThemedPageMixin, SettingsPageMixin, LibraryDataVie
 
     def get(self, request, *args, **kwargs):
         self.tip_shown = TipHistory.get_tip_to_show(request.clusive_user, 'Library')
+        self.tours = TourList(request.clusive_user, page='Library')
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['search_form'] = self.search_form
-        # BEGIN: Sample Tour
-        # Sample tour with single item list
         context['tip_name'] = None
-        context['tours'] = [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None
-        # END: Sample Tour
-        context['tip_shown'] = self.tip_shown
+        context['tip_shown'] = self.tip_shown.name if self.tip_shown else None
+        context['tours'] = self.tours
         context['has_teacher_resource'] = False
         context['has_bookshare_account'] = has_bookshare_account(self.request)
         return context
@@ -425,12 +423,13 @@ class ResourcesPageView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, 
 
     def get(self, request, *args, **kwargs):
         self.tip_shown = TipHistory.get_tip_to_show(request.clusive_user, self.page_name)
+        self.tours = TourList(request.clusive_user, page=self.page_name)
         self.extra_context = {
             'categories': EducatorResourceCategory.objects.all()
                 .prefetch_related(Prefetch('resources', queryset=Book.objects.order_by('resource_sort_order'))),
             'tip_name': None,
-            'tours': [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None,
-            'tip_shown': self.tip_shown,
+            'tip_shown': [self.tip_shown.name] if self.tip_shown else None,
+            'tours': self.tours,
             'has_teacher_resource': False,  # "Learn more" link is circular in this case.
             'clusive_user': request.clusive_user,
         }

--- a/src/pages/templates/pages/dashboard.html
+++ b/src/pages/templates/pages/dashboard.html
@@ -66,12 +66,5 @@
 
 </main>
 {% include "shared/partial/modal_vocab_check.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% include "shared/partial/modal_confirm.html" %}
-
 {% endblock %}

--- a/src/pages/templates/pages/partial/dashboard_panel_popular_reads.html
+++ b/src/pages/templates/pages/partial/dashboard_panel_popular_reads.html
@@ -1,4 +1,8 @@
 <div class="box box-mascot-tipped" {% if is_teacher %} data-clusive-tip-id="reading_data" {% endif %}>
+    {% if tip_name == "tour" %}
+    <span class="tip-mascot feature-novis" data-clusive-tip-id="tour" data-clusive-tip-action="tour"></span>
+    {% endif %}
+
     {% if is_teacher %}
         <h2>Student reading</h2>
     {% else %}

--- a/src/pages/templates/pages/reader.html
+++ b/src/pages/templates/pages/reader.html
@@ -388,11 +388,5 @@ var simplificationTool = "{{ simplification_tool }}";
 </div>
 
 {% include "shared/partial/modal_toc.html" %}
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% include "shared/partial/popover_simplify.html" %}
 {% endblock %}

--- a/src/pages/templates/pages/wordbank.html
+++ b/src/pages/templates/pages/wordbank.html
@@ -79,10 +79,4 @@
         </div>
     </div>
 </main>
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% endblock %}

--- a/src/pages/templatetags/list_helpers.py
+++ b/src/pages/templatetags/list_helpers.py
@@ -1,0 +1,29 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter(is_safe=True)
+def list_index(sequence, position):
+    try:
+        return sequence[position]
+    except:
+        return None
+
+@register.filter(is_safe=True)
+def list_index_prev(sequence, position):
+    if 0 >= position:
+        return None
+    try:
+        return sequence[int(position) - 1]
+    except:
+        return None
+
+@register.filter(is_safe=True)
+def list_index_next(sequence, position):
+    if len(sequence) - 1 == position:
+        return None
+    try:
+        return sequence[int(position) + 1]
+    except:
+        return None

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -225,8 +225,9 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         context['panels'] = self.panels
         context['data'] = self.data
         context['clusive_user'] = self.clusive_user
-        context['tip_name'] = None
-        context['tip_shown'] = self.tip_shown.name if self.tip_shown else None
+        # 'tour' is a special case and uses the older tooltip functionality
+        context['tip_name'] = 'tour' if self.tip_shown and self.tip_shown.name == 'tour' else None # tour tooltip
+        context['tip_shown'] = self.tip_shown.name if self.tip_shown and self.tip_shown.name != 'tour' else None # Singleton tour item
         context['tours'] = self.tours
         context['has_teacher_resource'] = True
         return context

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -28,7 +28,7 @@ from glossary.views import choose_words_to_cue
 from library.models import Book, BookVersion, Paradata, Annotation, BookTrend, \
     Customization, BookAssignment
 from roster.models import ClusiveUser, Period, Roles, UserStats, Preference
-from tips.models import TipHistory, CTAHistory, CompletionType
+from tips.models import TipHistory, CTAHistory, CompletionType, TourList
 from translation.util import TranslateApiManager
 
 logger = logging.getLogger(__name__)
@@ -128,6 +128,7 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         self.dashboard_popular_view = self.clusive_user.dashboard_popular_view
 
         self.tip_shown = TipHistory.get_tip_to_show(self.clusive_user, page='Dashboard')
+        self.tours = TourList(self.clusive_user, page='Dashboard')
 
         # Decision-making data
         user_stats = UserStats.objects.get(user=request.clusive_user)
@@ -224,12 +225,9 @@ class DashboardView(LoginRequiredMixin, ThemedPageMixin, SettingsPageMixin, Even
         context['panels'] = self.panels
         context['data'] = self.data
         context['clusive_user'] = self.clusive_user
-        # BEGIN: Sample Tour
-        # Sample tour with single item list
         context['tip_name'] = None
-        context['tours'] = [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None
-        # END: Sample Tour
-        context['tip_shown'] = self.tip_shown
+        context['tip_shown'] = self.tip_shown.name if self.tip_shown else None
+        context['tours'] = self.tours
         context['has_teacher_resource'] = True
         return context
 
@@ -691,6 +689,7 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
 
         # See if there's a Tip that should be shown
         self.tip_shown = TipHistory.get_tip_to_show(clusive_user, page=self.page_name, version_count=len(versions))
+        self.tours = TourList(clusive_user, page=self.page_name)
 
         # See if there's a custom question
         customizations = Customization.objects.filter(book=book, periods=clusive_user.current_period) \
@@ -718,12 +717,9 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
             'annotations': annotationList,
             'cuelist': json.dumps(cuelist),
             'hide_cues': hide_cues,
-            # BEGIN: Sample Tour
-            # Sample tour with single item list
             'tip_name': None,
-            'tours': [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None,
-            # END: Sample Tour
-            'tip_shown': self.tip_shown,
+            'tip_shown': self.tip_shown.name if self.tip_shown else None,
+            'tours': self.tours,
             'has_teacher_resource': True,
             'customization': customizations[0] if customizations else None,
             'starred': pdata.starred,
@@ -748,13 +744,14 @@ class WordBankView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPage
         # Check for Tip
         clusive_user = request.clusive_user
         tip_shown = TipHistory.get_tip_to_show(clusive_user, page='Wordbank')
+        tours = TourList(clusive_user, page='Wordbank')
 
         self.extra_context = {
             'words': WordModel.objects.filter(user=request.clusive_user, interest__gt=0).order_by('word'),
             'clusive_user': clusive_user,
             'tip_name': None,
-            'tours': [{'name': tip_shown.name, 'robust': True }] if tip_shown else None,
-            'tip_shown': tip_shown,
+            'tip_shown': tip_shown.name if tip_shown else None,
+            'tours': tours,
             'has_teacher_resource': False,
         }
         return super().get(request, *args, **kwargs)

--- a/src/pages/views.py
+++ b/src/pages/views.py
@@ -689,7 +689,7 @@ class ReaderView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
 
         # See if there's a Tip that should be shown
         self.tip_shown = TipHistory.get_tip_to_show(clusive_user, page=self.page_name, version_count=len(versions))
-        self.tours = TourList(clusive_user, page=self.page_name)
+        self.tours = TourList(clusive_user, page=self.page_name, version_count=len(versions))
 
         # See if there's a custom question
         customizations = Customization.objects.filter(book=book, periods=clusive_user.current_period) \

--- a/src/roster/templates/roster/manage.html
+++ b/src/roster/templates/roster/manage.html
@@ -87,13 +87,7 @@
     <p>
         If you have made changes to your Google Classroom class roster (e.g., you added or removed a student), use this option to update your class list in Clusive.
     </p>
-    {% endif %}    
+    {% endif %}
     {% endif %}
 </main>
-{% for tour in tours %}
-{% include "shared/partial/popover_tour.html" with tour_name=tour.name tour_robust=tour.robust %}
-{% endfor %}
-{% if tip_name %}
-{% include "shared/partial/tooltip_tip.html" %}
-{% endif %}
 {% endblock %}

--- a/src/roster/views.py
+++ b/src/roster/views.py
@@ -49,7 +49,7 @@ from roster.forms import SimpleUserCreateForm, UserEditForm, UserRegistrationFor
 from roster.models import ClusiveUser, Period, PreferenceSet, Roles, ResearchPermissions, MailingListMember, \
     RosterDataSource
 from roster.signals import user_registered
-from tips.models import TipHistory
+from tips.models import TipHistory, TourList
 
 logger = logging.getLogger(__name__)
 
@@ -472,6 +472,7 @@ class ManageView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
         user = request.clusive_user
         # See if there's a Tip that should be shown
         self.tip_shown = TipHistory.get_tip_to_show(user, page="Manage")
+        self.tours = TourList(user, page="Manage")
         if not user.can_manage_periods:
             self.handle_no_permission()
         return super().get(request, *args, **kwargs)
@@ -481,12 +482,9 @@ class ManageView(LoginRequiredMixin, EventMixin, ThemedPageMixin, SettingsPageMi
         if self.current_period is not None:
             context['people'] = self.make_people_info_list(self.request.user)
             context['period_name_form'] = PeriodNameForm(instance=self.current_period)
-        # BEGIN: Sample Tour
-        # Sample tour with single item list
         context['tip_name'] = None
-        context['tours'] = [{'name': self.tip_shown.name, 'robust': True }] if self.tip_shown else None
-        # END: Sample Tour
-        context['tip_shown'] = self.tip_shown
+        context['tip_shown'] = [self.tip_shown.name] if self.tip_shown else None
+        context['tours'] = self.tours
         context['has_teacher_resource'] = False # "Learn more" link would be circular
         context['clusive_user'] = self.request.clusive_user
         return context

--- a/src/shared/templates/shared/base.html
+++ b/src/shared/templates/shared/base.html
@@ -77,20 +77,12 @@
     {% if tip_name %}
     {% include "shared/partial/tooltip_tip.html" %}
     {% endif %}
-<div>
-TOURS: {{ tours }}<br>
-TIP_NAME: {{ tip_name }}<br>
-TIP_SHOWN: {{ tip_shown }}<br>
-</div>
+
     <div id="tourContainer" class="tour-container" >
     {% comment %}<!-- touring popovers to use this element for their `container` and `viewport` options -->{% endcomment %}
     </div>
     <div id="features" class="features" aria-live="assertive" aria-atomic="true">
-    </div>
-    <div class="content-container container-xl">
-        <div class="content">
-            <span data-clusive-tip-id="context" data-cfw-popover-placement="right auto" class="feature-context feature-novis"></span>
-        </div>
+        <span data-clusive-tip-id="context" data-cfw-popover-placement="bottom auto" class="feature-context feature-novis"></span>
     </div>
 
     <div id="notifyContainer" class="notify-container" aria-live="assertive"></div>

--- a/src/shared/templates/shared/base.html
+++ b/src/shared/templates/shared/base.html
@@ -50,7 +50,10 @@
                     {% block sidebar_bottom_start %}
                     {% include "shared/partial/sidebar_bottom_start.html" with show_reading_feedback=False %}
                     {% endblock%}
+                </div>
+                <div class="sidebar sidebar-end">
                     {% block sidebar_bottom_end %}
+                    {% include "shared/partial/sidebar_bottom_end.html" %}
                     {% endblock%}
                 </div>
             </div>
@@ -68,6 +71,17 @@
         </button>
     {% endif %}
 
+    {% if tours %}
+    {% include "shared/partial/popover_tour.html" %}
+    {% endif %}
+    {% if tip_name %}
+    {% include "shared/partial/tooltip_tip.html" %}
+    {% endif %}
+<div>
+TOURS: {{ tours }}<br>
+TIP_NAME: {{ tip_name }}<br>
+TIP_SHOWN: {{ tip_shown }}<br>
+</div>
     <div id="tourContainer" class="tour-container" >
     {% comment %}<!-- touring popovers to use this element for their `container` and `viewport` options -->{% endcomment %}
     </div>

--- a/src/shared/templates/shared/partial/popover_tour.html
+++ b/src/shared/templates/shared/partial/popover_tour.html
@@ -1,11 +1,8 @@
 {% load i18n %}
+{% for tour_name in tours %}
 <div id="tour_{{ tour_name }}" class="popover popover-tour popover-scrollable">
-    {% if tour_robust %}
-    {% if tours|length > 1 %}
-    <button type="button" class="close" aria-label="Close" onclick="tour.closeRefocus('#tourStart');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
-    {% else %}
-    <button type="button" class="close" aria-label="Close" data-cfw-dismiss="popover"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
-    {% endif %}
+    <button type="button" class="close touring-on" aria-label="Close" onclick="tour.closeRefocus('#tourStart');"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
+    <button type="button" class="close touring-off" aria-label="Close" data-cfw-dismiss="popover"><span class="icon-cancel-circled2" aria-hidden="true"></span></button>
     <div class="popover-header">
         <span class="h3">
         {% if tour_name == "settings" %}
@@ -59,7 +56,6 @@
             </div>
         </div>
     </div>
-    {% endif %}
     <div class="popover-body">
         {% if tour_name == "settings" %}
 <!-- settings -->
@@ -67,74 +63,38 @@
             <iframe id="settingsIframe" src="https://videos.sproutvideo.com/embed/a79edbb41414e7c72e/96f3dfacf85e2603?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Settings video"></iframe>
         </div>
         <p>Change the font, colors, and more! Settings let you choose the look, supports, and reading tools to make Clusive all your own.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' resource_id='SSETTINGS' %}">Learn more<span class="sr-only"> about settings</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SSETTINGS" resource_name="settings" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "readaloud" %}
 <!-- readaloud -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="readaloudIframe" src="https://videos.sproutvideo.com/embed/449edbb51c1ae6cecd/90717ea3b61bbdd3?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Read aloud video"></iframe>
         </div>
         <p>Click the page read aloud icon to hear the entire page. Select text and click read aloud in the context menu to hear a smaller selection or a single word read aloud.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <!-- 'readaloud' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                        <a href="#" tabindex="-1"></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        <!-- 'readaloud' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "wordbank" %}
 <!-- wordbank -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="wordbankIframe" src="https://videos.sproutvideo.com/embed/ac9edbbb161fe1c025/5cb0b244a6a441c9?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Word bank video"></iframe>
         </div>
         <p>The Word bank collects words you’ve looked up or rated. Check out how you’ve rated words. Change ratings as your word knowledge grows. Get back to your previous page by clicking on the back button.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <!-- 'wordbank' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                        <a href="#" tabindex="-1"></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        <!-- 'wordbank' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "switch" %}
 <!-- switch -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="switchIframe" src="https://videos.sproutvideo.com/embed/d39edbbb161ae0c75a/7acc94350bf3dd31?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Switch video"></iframe>
         </div>
         <p>Switch gives three challenge options for some texts. Open Switch, check out the vocabulary in each version, and choose to stay, or change challenge levels. It’s up to you!</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' resource_id='SWITCH' %}">Learn more<span class="sr-only"> about switch</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SWITCH" resource_name="switch" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "context" %}
 <!-- context -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
@@ -147,38 +107,16 @@
             <li><span class="feature-icon icon-switch" aria-hidden="true"></span> Translate or simplify</li>
             <li><span class="feature-icon icon-play-circled2" aria-hidden="true"></span> Hear the words read aloud</li>
         </ul>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <!-- 'context' type popovers do not have a "Learn more" resource link yet, so this is blank -->
-                        <a href="#" tabindex="-1"></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto tooltip-action">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        <!-- 'context' type popovers do not have a "Learn more" resource link yet, so this is blank -->
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "view" %}
 <!-- view -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="viewIframe" src="https://videos.sproutvideo.com/embed/ac9edbbb141fe6c525/86b0cbe36e2ab800?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Library Views video"></iframe>
         </div>
         <p>View the Clusive library by all readings, or in smaller groupings like class readings, readings you’ve starred, public readings, or readings you’ve uploaded.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <!-- 'view' type popovers currently do not have a "Learn more" resource link yet, so this is blank -->
-                        <a href="#" tabindex="-1"></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        <!-- 'view' type popovers currently do not have a "Learn more" resource link yet, so this is blank -->
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "book_actions" %}
 <!-- book_actions -->
         {% if clusive_user.role == 'TE' %}
@@ -187,18 +125,11 @@
         </div>
         {% endif %}
         <p>Click “More actions” (three dots) to assign or customize any book, and for books you uploaded to Clusive, to edit information or delete a book.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' 'CREAD' %}">Learn more<span class="sr-only"> about book actions</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="CREAD" resource_name="book actions" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "activity" %}
 <!-- activity -->
         {% if clusive_user.role == 'TE' %}
@@ -208,18 +139,11 @@
         {% endif %}
         <p>Get a quick overview of student activity. Hover over active reading time bars for titles and reading time. Click a bar to see readings students have in common. Triangles show readings you have assigned.</p>
         <p>Select timeframe and sort by hours, books, or student name.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' 'READDTL' %}">Learn more<span class="sr-only"> about student activities data</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="READDTL" resource_name="student activities data" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "student_reactions" %}
 <!-- student_reactions -->
         {% if clusive_user.role == 'TE' %}
@@ -228,18 +152,11 @@
         </div>
         {% endif %}
         <p>Click on a reaction word and see a list of Clusive readings that have inspired your students, and other Clusive readers, to react with that word.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                    <a href="{% url 'res_reader' 'SREACT' %}">Learn more<span class="sr-only"> about students&apos; reactions</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SREACT" resource_name="students&apos; reactions" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "reading_data" %}
 <!-- reading_data -->
         {% if clusive_user.role == 'TE' %}
@@ -248,31 +165,18 @@
         </div>
         {% endif %}
         <p>Get a quick view of student reading interests and learning. Check out reading data on assigned and popular readings. Get a summary of student self-rating of learning, and see answers to prompts you have customized.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' 'SREADP' %}">Learn more<span class="sr-only"> about students&apos; reactions</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="SREADP" resource_name="student reading data" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "thoughts" %}
 <!-- thoughts -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="thoughtsIframe" src="https://videos.sproutvideo.com/embed/449ed4bf1c1ee2cbcd/7eeb1eb5c62a2389?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Your thoughts video"></iframe>
         </div>
         <p>Click on a reaction word and see Clusive readings that inspired you and others to react with that word.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "manage" %}
 <!-- manage -->
         {% if clusive_user.role == 'TE' %}
@@ -281,18 +185,11 @@
         </div>
         {% endif %}
         <p>Import, add or edit classes and student information in Clusive.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'res_reader' 'CCLASS' %}">Learn more<span class="sr-only"> about manage</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="CCLASS" resource_name="manage" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "resources" %}
 <!-- resources -->
         {% if clusive_user.role == 'TE' %}
@@ -301,66 +198,41 @@
         </div>
         {% endif %}
         <p>Get tips, resources and videos for getting you and your students started in Clusive, and for building teaching skills with Clusive tools and features.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-                {% if has_teacher_resource %}
-                    {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
-                        <a href="{% url 'resources' %}">Learn more<span class="sr-only"> about resources</span></a>
-                    {% endif %}
-                {% endif %}
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% if clusive_user.role == 'TE' or clusive_user.role == 'PA' %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id="RESOURCES" resource_name="resources" %}
+        {% else %}
+            {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
+        {% endif %}
         {% elif tour_name == "filters" %}
 <!-- filters -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="filtersIframe" src="https://videos.sproutvideo.com/embed/a79ed4bf1c1ee2c42e/ed4f87afb4202c31?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Filters video"></iframe>
         </div>
         <p>Use filters to find readings based on topics, reading levels, and word count. Click on one or more topics or filters and get readings that match any of your selections.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% elif tour_name == "search" %}
 <!-- search -->
         <div class="embed-fluid embed-fluid-16x9 mb-0_5">
             <iframe id="searchIframe" src="https://videos.sproutvideo.com/embed/709ed4bf1c1ee2c7f9/9df1a9c8d1be124a?type=hd" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen aria-label="Search video"></iframe>
         </div>
         <p>Search for readings by part of all of a title, author name, publisher, even words that are included in the descriptions on reading tiles. Looking for topic or subject areas? Use the Library filters instead!.</p>
-        <div class="row gx-0_5 flex-items-center">
-            <div class="col">
-            </div>
-            <div class="col-auto">
-                <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
-            </div>
-        </div>
+        {% include "shared/partial/popover_tour_footer.html" with resource_id=None %}
         {% endif %}
     </div>
     {% if tour_name != "context" and tour_name != "activity" %}
     <div class="popover-arrow"></div>
     {% endif %}
 </div>
+{% endfor %}
+{% if tours %}
 <script>
 $(window).ready(function() {
-    tour.prepare('[data-clusive-tip-id="{{ tour_name }}"]');
-
-    {% if tours|length == 1 %}
-    var tip_control = document.querySelector('[data-clusive-tip-id="{{ tour_name }}"]');
-    if (tip_control) {
-        var $tip_control = $(tip_control);
-        $tip_control.one('afterShow.cfw.popover', function() {
-            popoverHelpDialog = $('#tour_{{ tour_name }}').focus();
-            if (popoverHelpDialog.is(':visible')) {
-                window.parent.clusiveEvents.addTipViewToQueue('{{ tour_name }}');
-            }
-        });
-        $tip_control.CFW_Popover('show');
-    }
+    {% for name in tours %}
+    tour.prepare('{{ name }}');
+    {% endfor %}
+    {% if tip_shown %}
+    tour.singleton('{{ tip_shown }}');
     {% endif %}
 });
 </script>
+{% endif %}

--- a/src/shared/templates/shared/partial/popover_tour_footer.html
+++ b/src/shared/templates/shared/partial/popover_tour_footer.html
@@ -5,7 +5,7 @@
     <div class="col">
         {% if has_teacher_resource and resource_id %}
             {% if resource_id == 'RESOURCES' %}
-            <a href="{% url 'resources' %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+            <a href="{% url 'resources' %}" data-clusive-tip-action="resource_id">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
             {% else %}
             <a href="{% url 'res_reader' resource_id=resource_id %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
             {% endif %}

--- a/src/shared/templates/shared/partial/popover_tour_footer.html
+++ b/src/shared/templates/shared/partial/popover_tour_footer.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load list_helpers %}
+
+<div class="row gx-0_5 flex-items-center">
+    <div class="col">
+        {% if has_teacher_resource and resource_id %}
+            {% if resource_id == 'RESOURCES' %}
+            <a href="{% url 'resources' %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+            {% else %}
+            <a href="{% url 'res_reader' resource_id=resource_id %}">Learn more<span class="sr-only"> about {{ resource_name }}</span></a>
+            {% endif %}
+        {% endif %}
+    </div>
+    {% if tours|list_index_prev:forloop.counter0 %}
+    <div class="col-auto touring-on">
+        <button type="button" class="btn btn-primary" onclick="tour.chain('#tour_{{ tours|list_index_prev:forloop.counter0 }}');"><span class="fa fa-chevron-left" aria-hidden="true"></span> <span aria-hidden="true">Prev</span><span class="sr-only">Previous</span></button>
+    </div>
+    {% endif %}
+    <div class="col-auto touring-on">
+        {{ forloop.counter }}/{{ tours|length }}
+    </div>
+    <div class="col-auto touring-on">
+        {% if tours|list_index_next:forloop.counter0 %}
+        <button type="button" class="btn btn-secondary" onclick="tour.chain('#tour_{{ tours|list_index_next:forloop.counter0 }}');">Next <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
+        {% else %}
+        <button type="button" class="btn btn-secondary" onclick="tour.closeRefocus('#tourStart');">End</button>
+        {% endif %}
+    </div>
+    <div class="col-auto touring-off">
+        <button type="button" class="btn btn-primary" data-cfw-dismiss="popover">Got it!</button>
+    </div>
+</div>

--- a/src/shared/templates/shared/partial/sidebar_bottom_end.html
+++ b/src/shared/templates/shared/partial/sidebar_bottom_end.html
@@ -1,0 +1,10 @@
+{% load array_helpers %}
+<div class="sidebar-region sidebar-support" role="region" aria-label="User support">
+    {% if tours %}
+    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped mt-0_75" onclick="tour.chain('#tour_{{ tours|get_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
+    {% else %}
+    <span class="d-inline-block mt-0_75" tabindex="0" title="There are currently no tool tips on this page." data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="reverse">
+        <button type="button" class="btn btn-tool btn-mascot-tipped" disabled><span class="sr-only">There are currently no tool tips on this page.</span></button>
+    </span>
+    {% endif %}
+</div>

--- a/src/shared/templates/shared/partial/sidebar_bottom_end.html
+++ b/src/shared/templates/shared/partial/sidebar_bottom_end.html
@@ -1,7 +1,7 @@
-{% load array_helpers %}
+{% load list_helpers %}
 <div class="sidebar-region sidebar-support" role="region" aria-label="User support">
     {% if tours %}
-    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped mt-0_75" onclick="tour.chain('#tour_{{ tours|get_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
+    <button id="tourStart" type="button" class="btn btn-tool btn-mascot-tipped mt-0_75" onclick="tour.chain('#tour_{{ tours|list_index:0 }}');"><span class="sr-only">Start tour of features</span></button>
     {% else %}
     <span class="d-inline-block mt-0_75" tabindex="0" title="There are currently no tool tips on this page." data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="reverse">
         <button type="button" class="btn btn-tool btn-mascot-tipped" disabled><span class="sr-only">There are currently no tool tips on this page.</span></button>

--- a/src/shared/templates/shared/partial/tooltip_tip.html
+++ b/src/shared/templates/shared/partial/tooltip_tip.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-<div id="tip" class="tooltip tooltip-feature">
+{% load list_helpers %}
+<div id="tip" class="tooltip tooltip-feature{% if tip_name == "tour" %} tooltip-tour{% endif %}">
     <div class="tooltip-body">
         {% if tip_name == "settings" %}
         <p><strong>Settings:</strong> Change the font, colors, and more!</p>
@@ -71,6 +72,12 @@
                 </div>
                 <span class="d-none open" data-cfw="collapse" data-cfw-collapse-target="#activityFeature0" data-cfw-collapse-animate="false">Previous</span>
             </div>
+        </div>
+        {% elif tip_name == "tour" %}
+        <p>To get a tour of this page, click on me in the lower right anytime!</p>
+        <div class="tooltip-action">
+            <button type="button" class="btn btn-secondary me-0_5" onclick="tour.chain('#tour_{{ tours|list_index:0 }}');">Start tour now</button>
+            <button type="button" class="btn btn-primary" data-cfw-dismiss="tooltip">Got it!</button>
         </div>
         {% endif %}
     </div>

--- a/src/tips/fixtures/tiptypes.json
+++ b/src/tips/fixtures/tiptypes.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "name": "settings",
-      "priority": 1,
+      "priority": 2,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -14,7 +14,7 @@
     "pk": 2,
     "fields": {
       "name": "readaloud",
-      "priority": 2,
+      "priority": 3,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -24,7 +24,7 @@
     "pk": 3,
     "fields": {
       "name": "context",
-      "priority": 3,
+      "priority": 4,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -34,7 +34,7 @@
     "pk": 4,
     "fields": {
       "name": "switch",
-      "priority": 4,
+      "priority": 5,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -44,7 +44,7 @@
     "pk": 5,
     "fields": {
       "name": "wordbank",
-      "priority": 5,
+      "priority": 6,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -54,7 +54,7 @@
     "pk": 6,
     "fields": {
       "name": "view",
-      "priority": 6,
+      "priority": 7,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -64,7 +64,7 @@
     "pk": 7,
     "fields": {
       "name": "book_actions",
-      "priority": 7,
+      "priority": 8,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -74,7 +74,7 @@
     "pk": 8,
     "fields": {
       "name": "activity",
-      "priority": 8,
+      "priority": 9,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -84,7 +84,7 @@
     "pk": 9,
     "fields": {
       "name": "student_reactions",
-      "priority": 9,
+      "priority": 10,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -94,7 +94,7 @@
     "pk": 10,
     "fields": {
       "name": "reading_data",
-      "priority": 10,
+      "priority": 11,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -104,7 +104,7 @@
     "pk": 11,
     "fields": {
       "name": "thoughts",
-      "priority": 11,
+      "priority": 12,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -114,7 +114,7 @@
     "pk": 12,
     "fields": {
       "name": "manage",
-      "priority": 12,
+      "priority": 13,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -124,7 +124,7 @@
     "pk": 13,
     "fields": {
       "name": "resources",
-      "priority": 13,
+      "priority": 14,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -134,7 +134,7 @@
     "pk": 14,
     "fields": {
       "name": "filters",
-      "priority": 14,
+      "priority": 15,
       "max": 3,
       "interval": "7 00:00:00"
     }
@@ -144,9 +144,20 @@
     "pk": 15,
     "fields": {
       "name": "search",
-      "priority": 15,
+      "priority": 16,
+      "max": 3,
+      "interval": "7 00:00:00"
+    }
+  },
+  {
+    "model": "tips.tiptype",
+    "pk": 15,
+    "fields": {
+      "name": "tour",
+      "priority": 1,
       "max": 3,
       "interval": "7 00:00:00"
     }
   }
+
 ]

--- a/src/tips/models.py
+++ b/src/tips/models.py
@@ -21,6 +21,7 @@ TEACHER_ONLY_TIPS = [
 # The order of popovers for a given page matches the tour order.  See:
 # https://castudl.atlassian.net/browse/CSL-2040?focusedCommentId=36802
 DASHBOARD_TIPS = [
+    'tour',
     'student_reactions',
     'reading_data',
     'activity',
@@ -377,6 +378,9 @@ def TourList(user: ClusiveUser, page: str, version_count=0):
     available = []
 
     for name in full:
+        # Tooltip version of tips are not part of tour
+        if name == 'tour':
+            continue
         # Teacher/parent-only tips
         if user.role == Roles.STUDENT and name in TEACHER_ONLY_TIPS:
             continue

--- a/src/tips/models.py
+++ b/src/tips/models.py
@@ -391,6 +391,4 @@ def TourList(user: ClusiveUser, page: str, version_count=0):
             continue
         available.append(name)
 
-    logger.debug('AVAILABLE: %s', repr(available))
-
     return available if len(available) > 1 else None

--- a/src/tips/models.py
+++ b/src/tips/models.py
@@ -369,3 +369,20 @@ class CTAHistory(models.Model):
         return [h for h in histories
                 if h.type.can_show(page)
                 and h.ready_to_show(user_stats)]
+
+
+def TourList(user: ClusiveUser, page: str):
+    # See rules in TipType.can_show()
+    full = PAGE_TIPS_MAP[page]
+    available = []
+
+    for name in full:
+        # Teacher/parent-only tips
+        if user.role == Roles.STUDENT and name in TEACHER_ONLY_TIPS:
+            continue
+        # Thoughts TipType is only for students
+        if name == 'thoughts' and user.role != Roles.STUDENT:
+            continue
+        available.append(name)
+
+    return available if len(available) > 1 else None

--- a/src/tips/models.py
+++ b/src/tips/models.py
@@ -371,7 +371,7 @@ class CTAHistory(models.Model):
                 and h.ready_to_show(user_stats)]
 
 
-def TourList(user: ClusiveUser, page: str):
+def TourList(user: ClusiveUser, page: str, version_count=0):
     # See rules in TipType.can_show()
     full = PAGE_TIPS_MAP[page]
     available = []
@@ -379,6 +379,9 @@ def TourList(user: ClusiveUser, page: str):
     for name in full:
         # Teacher/parent-only tips
         if user.role == Roles.STUDENT and name in TEACHER_ONLY_TIPS:
+            continue
+        # Switch TipType requires multiple versions
+        if name == 'switch' and not version_count > 1:
             continue
         # Thoughts TipType is only for students
         if name == 'thoughts' and user.role != Roles.STUDENT:


### PR DESCRIPTION
Dependency: #328
Supersedes: #327

Re-implements the chained popover tour based on revised popover tips.

The 'singleton' tour item, or the one that shows up automatically based on page and history conditions needs to be part of the larger tour list for a given page.  For example, on the reader page in order to show `'settings'` popover on page load it needs to be included in the full tour list - currently comprised of the list `['switch', 'settings', 'readaloud', 'context', 'thoughts', 'wordbank']`
