### PR TITLE
NOJIRA: ALLOWED_HOSTS Update to remove broken wildcard and hard-coded…

### DIFF
--- a/src/clusive_project/settings_https.py
+++ b/src/clusive_project/settings_https.py
@@ -28,7 +28,6 @@ ALLOWED_HOSTS = ['clusive.cast.org',
                  'cisl-demo.qa.cast.org',
                  'localhost',
                  '127.0.0.1',
-                 '10.*',
                  '[::1]']
 
 

--- a/src/clusive_project/settings_local.py
+++ b/src/clusive_project/settings_local.py
@@ -2,6 +2,7 @@
 Django settings for Clusive local development.  Not to be used in production.
 """
 import os
+from socket import gethostname, gethostbyname, gethostbyname_ex
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -17,10 +18,9 @@ MEDIA_URL = '/uploads/'
 ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
-    '10.*',
     '[::1]',
-    '10.21.12.86'
-]
+    gethostname(),
+] + list(set(gethostbyname_ex(gethostname())[2]))
 
 INTERNAL_IPS = [
     '127.0.0.1',


### PR DESCRIPTION
… local dev IP

I am to blame for the 10.* IP address includes in the settings configurations.  I had added them to help with local development and testing with mobile devices.

This change allows for auto determination, and inclusion, of the IP and hostnames for local development.

References:
-  https://stackoverflow.com/a/40665906
- https://code.djangoproject.com/ticket/27485
- https://pythontic.com/modules/socket/gethostbyname_ex