### PR TITLE
CSL-2110 Transfer progress bar to CAST's github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ wordfreq==2.5.1
 # Release 1.1 drops support for Python 3.7, so can't upgrade
 alt-profanity-check==1.0.2.1
 -e git+https://github.com/IMSGlobal/caliper-python@1.1.0.2#egg=imsglobal_caliper
--e git+https://github.com/klown/django-progressbarupload@fix/django-version#egg=django-progressbarupload
+-e git+https://github.com/cast-org/django-progressbarupload@fix/django-version#egg=django-progressbarupload
 -e git+https://github.com/cast-org/django-session-timeout#egg=django-session-timeout


### PR DESCRIPTION
This changes the `requirements.txt` to point to CAST's fork of the `django-progressbarupload` project, specifically its `fix/django-version` branch.

JIRA: https://castudl.atlassian.net/browse/CSL-2110
