### PR TITLE
NOJIRA: Add a management script to reset tip histories

### DIFF
--- a/src/tips/management/commands/reset_tips_histories.py
+++ b/src/tips/management/commands/reset_tips_histories.py
@@ -1,7 +1,10 @@
+import logging
 from django.core.management.base import BaseCommand, CommandError
 
-from django.contrib.auth.models import User
+from roster.models import ClusiveUser
 from tips.models import TipHistory
+
+logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = 'In the tip history table, reset these field values:\n' \
@@ -17,27 +20,27 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         uname = options['username']
         if uname:
-            user = User.objects.filter(username=uname)
-            if user:
-                self.reset_one_user_tip_history(user[0].id, uname)
-            else:
+            try:
+                clusive_user = ClusiveUser.objects.get(user__username=uname)
+            except ClusiveUser.DoesNotExist:
                 raise CommandError('User name \'%s\' not found' % uname)
+            self.reset_one_user_tip_history(clusive_user.id, uname)
         else:
             self.reset_all_tip_histories()
 
-    def reset_a_tip_history(self, tip):
-        tip.show_count = 0
-        tip.last_attempt = None
-        tip.last_show = None
-        tip.last_action = None
-        tip.save()
+    def reset_a_tip_history(self, tip_history):
+        tip_history.show_count = 0
+        tip_history.last_attempt = None
+        tip_history.last_show = None
+        tip_history.last_action = None
+        tip_history.save()
 
     def reset_one_user_tip_history(self, uid, uname):
-        for tip in TipHistory.objects.filter(user_id=uid):
-            tip = self.reset_a_tip_history(tip)
-        self.stdout.write("Done: the tip history is reset for the user '" + uname + "'")
+        for tip_history in TipHistory.objects.filter(user_id=uid):
+            self.reset_a_tip_history(tip_history)
+        logger.info("Done: the tip history is reset for the user '" + uname + "'")
 
     def reset_all_tip_histories(self):
-        for tip in TipHistory.objects.all():
-            tip = self.reset_a_tip_history(tip)
-        self.stdout.write("Done: all tip histories are reset")
+        for tip_history in TipHistory.objects.all():
+            self.reset_a_tip_history(tip_history)
+        logger.info("Done: all tip histories are reset")

--- a/src/tips/management/commands/reset_tips_histories.py
+++ b/src/tips/management/commands/reset_tips_histories.py
@@ -1,0 +1,43 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from django.contrib.auth.models import User
+from tips.models import TipHistory
+
+class Command(BaseCommand):
+    help = 'In the tip history table, reset these field values:\n' \
+           '1. reset the show count to 0\n' \
+           '2. reset all timestamps to null including the last show, the last attempt and the last action\n' \
+           'If a user name is given as an argument, above values for this user will be reset.\n' \
+           'If no argument is given, all above values in the tip history table will be reset.\n' \
+           '\n'
+
+    def add_arguments(self, parser):
+        parser.add_argument('username', nargs='?', type=str)
+
+    def handle(self, *args, **options):
+        uname = options['username']
+        if uname:
+            user = User.objects.filter(username=uname)
+            if user:
+                self.reset_one_user_tip_history(user[0].id, uname)
+            else:
+                raise CommandError('User name \'%s\' not found' % uname)
+        else:
+            self.reset_all_tip_histories()
+
+    def reset_a_tip_history(self, tip):
+        tip.show_count = 0
+        tip.last_attempt = None
+        tip.last_show = None
+        tip.last_action = None
+        tip.save()
+
+    def reset_one_user_tip_history(self, uid, uname):
+        for tip in TipHistory.objects.filter(user_id=uid):
+            tip = self.reset_a_tip_history(tip)
+        self.stdout.write("Done: the tip history is reset for the user '" + uname + "'")
+
+    def reset_all_tip_histories(self):
+        for tip in TipHistory.objects.all():
+            tip = self.reset_a_tip_history(tip)
+        self.stdout.write("Done: all tip histories are reset")


### PR DESCRIPTION
Transferring @cindyli's script from my github repository.

The script will reset either a single user's tip histories, or all of the tip histories.

For example, to reset samstudent's tip histories:

```
$ python manage.py reset_tips_histories samstudent
```

Or, to reset all tip histories in the database:

```
$ $ python manage.py reset_tips_histories
```
 