### PR TITLE
NOJIRA:  Fix string representation of AffectiveBookTotal model 

### DIFF
--- a/src/assessment/models.py
+++ b/src/assessment/models.py
@@ -316,7 +316,7 @@ class AffectiveBookTotal(AffectiveSummary):
     book = models.ForeignKey(to=Book, on_delete=models.CASCADE, db_index=True)
 
     def __str__(self):
-        return '<AffBookTotal: %s>' % self.user
+        return '<AffBookTotal: %s>' % self.book
 
 
 class StarRatingScale:


### PR DESCRIPTION
The `__str__()` method of the `AffectiveBookTotal` model references a non-existent `user` field.  It should be referencing the actual `book` field.

This PR fixes that.

The error is not that serious in that it will only show up when something asks for the string representation of an `AffectiveBookTotal` record.  Otherwise, creating, retrieving, updating, and deleting `AffectiveBookTotal` records was working fine.