### PR TITLE
CSL-1787: Update alt-profanity-check to v1.1.1 and python to v3.8.16

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Note: all steps between **Create/Activitate Virtual Environment** and **Create a
 ### Prerequisites
 
 * [Python 3](https://www.python.org/downloads/)
-  * Version 3.7.4 up to 3.9. (3.10+ not tested yet). On Mac, Homebrew is the easiest way to install.
+  * Version 3.8.16 up to 3.9. (3.10+ not tested yet). On Mac, Homebrew is the easiest way to install.
 * Django
   * Version 3.2, installed with other Python dependencies as documented in
     section [Install Python Dependencies](#install-python-dependencies).

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ unidecode==1.3.6
 whitenoise==4.1.3
 wordfreq==2.5.1
 # Release 1.1 drops support for Python 3.7, so can't upgrade
-alt-profanity-check==1.0.2.1
+alt-profanity-check==1.1.1
 -e git+https://github.com/IMSGlobal/caliper-python@1.1.0.2#egg=imsglobal_caliper
 -e git+https://github.com/cast-org/django-progressbarupload@fix/django-version#egg=django-progressbarupload
 -e git+https://github.com/cast-org/django-session-timeout#egg=django-session-timeout


### PR DESCRIPTION
@bgoldowsky I updated my local development to use python to 3.8.16.  After running the unit and cypress tests successfully, and smoke-testing Clusive, I tried the upgrade of `alt-profanity-check` to version 1.1.1.  The unit, cypress and smoke-test all pass.  In particular, the simplify transformation appears to work -- I tested a word, and a paragraph.

As discussed at yesterday's technical meeting the warning messages no longer appear when you first run the server.  There's probably more things to investigate, but it's a start.