### PR TITLE
CSL-2046 Student details page fixes from Q/A issues

### DIFF
--- a/src/assessment/views.py
+++ b/src/assessment/views.py
@@ -15,6 +15,7 @@ from roster.models import Roles, ClusiveUser
 from .models import ComprehensionCheck, ComprehensionCheckResponse, AffectiveCheckResponse, \
     AffectiveUserTotal, AffectiveBookTotal
 
+
 logger = logging.getLogger(__name__)
 
 class AffectCheckView(LoginRequiredMixin, View):
@@ -217,6 +218,10 @@ class AffectDetailView(LoginRequiredMixin, TemplateView):
             # Find responses for the specific user and time period
             self.my_recent = AffectiveCheckResponse.recent_with_word(
                 clusive_user, self.word, request.clusive_user.student_activity_days)[0:10]
+            for recent in self.my_recent:
+                if not recent.book.is_visible_to(request.clusive_user):
+                    recent.unauthorized = True
+                    self.any_unauthorized_book = True
         else:
             # Find responses my the currently logged-in user
             self.my_recent = AffectiveCheckResponse.recent_with_word(clusive_user, self.word)[0:5]

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -744,7 +744,14 @@ class Paradata(models.Model):
                 if books_sort == ReadingDetailsSort.TIME:
                     reading_data_for_one_user['books'].sort(reverse=True, key=lambda item: item['hours'])
                 if books_sort == ReadingDetailsSort.LASTVIEW:
-                    reading_data_for_one_user['books'].sort(reverse=True, key=lambda item: item['last_view'])
+                    book_list = reading_data_for_one_user['books']
+                    last_view_null = []
+                    for abook in book_list:
+                        if abook['last_view'] is None:
+                            last_view_null.append(abook)
+                            book_list.remove(abook)
+                    book_list.sort(reverse=True, key=lambda item: item['last_view'])
+                    book_list.extend(last_view_null)
 
         return result
 

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -5,7 +5,7 @@ import math
 import os
 import textwrap
 from base64 import b64encode
-from datetime import timedelta, date
+from datetime import timedelta, date, datetime, MINYEAR
 from json import JSONDecodeError
 
 from django.core.files.storage import default_storage
@@ -17,6 +17,8 @@ from roster.models import ClusiveUser, Period, Roles, StudentActivitySort, Readi
 from .util import sort_words_by_frequency
 
 logger = logging.getLogger(__name__)
+
+VERY_LONG_TIME_AGO = timezone.make_aware(datetime(year=MINYEAR, month=1, day=1))
 
 def update_word_list(word_list, word):
     """
@@ -744,15 +746,7 @@ class Paradata(models.Model):
                 if books_sort == ReadingDetailsSort.TIME:
                     reading_data_for_one_user['books'].sort(reverse=True, key=lambda item: item['hours'])
                 if books_sort == ReadingDetailsSort.LASTVIEW:
-                    book_list = reading_data_for_one_user['books']
-                    last_view_null = []
-                    for abook in book_list:
-                        if abook['last_view'] is None:
-                            last_view_null.append(abook)
-                            book_list.remove(abook)
-                    book_list.sort(reverse=True, key=lambda item: item['last_view'])
-                    book_list.extend(last_view_null)
-
+                    reading_data_for_one_user['books'].sort(reverse=True, key=lambda item: item['last_view'] or VERY_LONG_TIME_AGO)
         return result
 
     @classmethod

--- a/src/roster/templates/roster/partial/student_details_reactions.html
+++ b/src/roster/templates/roster/partial/student_details_reactions.html
@@ -1,7 +1,7 @@
 <div class="box box-secondary">
     <h4 class="h2">Reactions</h4>
     <div class="box-divider"></div>
-    Strike up a class conversation based on what students are feeling about a reading.<br>
+    Click on a word to see how your student felt about those particular readings.<br>
     {% if student is None %}
         &quot;{{ current_student_username }}&quot; is not in this period. Below are the reactions of the students that are.<br>
     {% endif %}

--- a/src/roster/templates/roster/partial/student_details_reading_details.html
+++ b/src/roster/templates/roster/partial/student_details_reading_details.html
@@ -92,7 +92,7 @@
                             </td>
                         </tr>
                         {% endfor %}
-                    {% elif current_student %}
+                    {% elif data.current_student %}
                         <td colspan="7">No readings{% if data.days == 7 %} in the past week{% elif data.days == 30 %} in the past month{% endif %}.</td>
                     {% else %}
                         <td colspan="7">N/A</td>

--- a/src/roster/templates/roster/partial/student_details_reading_details.html
+++ b/src/roster/templates/roster/partial/student_details_reading_details.html
@@ -68,11 +68,7 @@
                             </th>
                             <td>{{ book.hours }} <span aria-hidden="true">hrs</span><br><span class="sr-only">hours</span> ({{ book.view_count }} visits)</td>
                             <td style="white-space:nowrap;">
-                                {% if book.last_view %}
-                                    {{ book.last_view | naturalday:"D, M d" }}
-                                {% else %}
-                                    Unknown
-                                {% endif %}
+                                {{ book.last_view | naturalday:"D, M d" | default:"Unknown" }}
                             </td>
                             <td class="d-sm-down-none">{{ book.words_looked_up | default:"&mdash;" }}</td>
                             <td class="d-sm-down-none">
@@ -102,6 +98,13 @@
                         <td colspan="7">N/A</td>
                     {% endif %}
                 </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="7">
+                            <p class="form-text"><em>Readings with the symbol <span class="icon-block" title="Not authorized to view"></span> were uploaded by the student.</em></p>
+                        </td>
+                    </tr>
+                </tfoot>
             </table>
         </div>
     </div>

--- a/src/roster/templates/roster/partial/student_details_reading_details.html
+++ b/src/roster/templates/roster/partial/student_details_reading_details.html
@@ -69,7 +69,13 @@
                             <td>{{ book.hours }} <span aria-hidden="true">hrs</span><br><span class="sr-only">hours</span> ({{ book.view_count }} visits)</td>
                             <td style="white-space:nowrap;">{{ book.last_view | naturalday:"D, M d" }}</td>
                             <td class="d-sm-down-none">{{ book.words_looked_up | default:"&mdash;" }}</td>
-                            <td class="d-sm-down-none">{{ book.learning | default:"&mdash;" }}</td>
+                            <td class="d-sm-down-none">
+                                {% if book.learned %}
+                                    {{ book.learned }} / {{ book.free_response | default:"&mdash;" }}
+                                {% else %}
+                                    &mdash;
+                                {% endif %}
+                            </td>
                             <td class="d-md-down-none">
                                 <span class="muted">{{ book.custom_question | default:"&mdash;" }}</span>
                                 {% if book.custom_response %}{{ book.custom_response }}{% endif %}

--- a/src/roster/templates/roster/partial/student_details_reading_details.html
+++ b/src/roster/templates/roster/partial/student_details_reading_details.html
@@ -67,7 +67,13 @@
                                 {% endif %}
                             </th>
                             <td>{{ book.hours }} <span aria-hidden="true">hrs</span><br><span class="sr-only">hours</span> ({{ book.view_count }} visits)</td>
-                            <td style="white-space:nowrap;">{{ book.last_view | naturalday:"D, M d" }}</td>
+                            <td style="white-space:nowrap;">
+                                {% if book.last_view %}
+                                    {{ book.last_view | naturalday:"D, M d" }}
+                                {% else %}
+                                    Unknown
+                                {% endif %}
+                            </td>
                             <td class="d-sm-down-none">{{ book.words_looked_up | default:"&mdash;" }}</td>
                             <td class="d-sm-down-none">
                                 {% if book.learned %}

--- a/src/roster/views.py
+++ b/src/roster/views.py
@@ -1484,15 +1484,15 @@ def get_book_details(books, period, clusiveStudent, clusiveUser):
             for category in book.reading_level_categories:
                 category_names.append(category.tag_name)
 
-            learning = None
+            learned = None
+            free_response = None
             if comp_check:
                 answer = comp_check.get_answer()
-                if answer and len(answer):
-                    free_response = comp_check.comprehension_free_response
-                    if free_response and len(free_response):
-                        learning = answer + '/' + free_response
-                    else:
-                        learning = answer
+                if answer and len(answer.strip()):
+                    learned = answer
+                    fresp = comp_check.comprehension_free_response
+                    if fresp and len(fresp.strip()):
+                        free_response = fresp
 
             if customization and customization.question and len(customization.question):
                 custom_question = '(' + customization.question + ')'
@@ -1512,7 +1512,8 @@ def get_book_details(books, period, clusiveStudent, clusiveUser):
                 'num_versions': num_versions,
                 'custom_question': custom_question,
                 'response': response.custom_response if response else None,
-                'learning': learning,
+                'learned': learned,
+                'free_response': free_response,
                 'reading_level': ', '.join(category_names),
                 'is_assigned': one_book['is_assigned'],
                 'version_switched': True if one_book['first_version'] and one_book['first_version'] != one_book['last_version'] else False,

--- a/src/roster/views.py
+++ b/src/roster/views.py
@@ -1553,6 +1553,7 @@ class ReadingDetailsPanelView(TemplateView):
                 periods__in=[self.current_period],
                 role__in=[Roles.STUDENT]
             )
+            self.clusive_student = clusive_student
             # Get the reading data for the current student. This data will be shared by all panels on the student details page
             reading_data = Paradata.get_reading_data(self.current_period, days=self.days, books_sort=self.sort, username=self.username)[0]
             self.paginator = self.setup_paginator(
@@ -1585,6 +1586,7 @@ class ReadingDetailsPanelView(TemplateView):
             'days': self.days,
             'paginator': self.paginator,
             'page_obj': self.page_obj,
+            'current_student': self.clusive_student,
         }
         return context
 

--- a/src/shared/templates/shared/partial/modal_student_details_affect.html
+++ b/src/shared/templates/shared/partial/modal_student_details_affect.html
@@ -7,13 +7,25 @@
     <ul class="list-unstyled">
     {% for reaction in my_recent %}
         <li class="mb-0_5">
+            {% if reaction.unauthorized %}
+            <a href="#" data-cfw="tooltip" title="Not authorized to view">
+                <span class="icon-block" title="Not authorized to view"></span>
+                <strong>{{ reaction.book.title }}</strong>
+            </a>
+            {% else %}
             <a href="#" onclick="vocabCheck.start(this, '{{reaction.book.id}}'); return false;">
                 <strong>{{ reaction.book.title }}</strong>
-            </a><br>
-            <em>{{ reaction.affect_free_response }}</em>
+            </a>
+            {% endif %}
+            {% if reaction.affect_free_response and reaction.affect_free_response.strip %}
+                <br><em>{{ reaction.affect_free_response }}</em>
+            {% endif %}
         </li>
     {% endfor %}
     </ul>
+    {% if any_unauthorized_book %}
+    <p class="form-text"><em>Readings with the symbol <span class="icon-block" title="Not authorized to view"></span> were uploaded by the student.</em></p>
+    {% endif %}
 {% else %}
     <p>No readings have made {{ for_user_name }} feel {{ word }}
         {% if time_scale == 7 %}


### PR DESCRIPTION
Q/A issues fixed:
- Reaction panel text, just above the reaction wheel
- Content of the reaction modal dialog:
  - If the reaction's free response is empty, do not show "None",
  - The do-not-enter sign is prepended to titles that the teacher is not authorized to view,
  - If any book is unauthorized, the unauthorized legend is displayed at the bottom of the dialog.
- Added spaces around the "/" in the Learning column that separates the amount learned and the free response,
- Handles corrupt data specifically when the last viewed time is `None`.  In that case, the book(s) is/are listed last.

JIRA:  https://castudl.atlassian.net/browse/CSL-2046

[CSL-2046]: https://castudl.atlassian.net/browse/CSL-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ